### PR TITLE
Pass the namespace when querying the logs.

### DIFF
--- a/src/api/app.ts
+++ b/src/api/app.ts
@@ -106,7 +106,7 @@ export function create(
             });
         }
     });
-    app.get('/api/logs/:nodeId/:container', async (req: express.Request, res: express.Response) => {
+    app.get('/api/logs/:namespace/:nodeId/:container', async (req: express.Request, res: express.Response) => {
         const logsSource = reactifyStringStream(
             core.ns(req.params.namespace).po(req.params.nodeId).log.getStream({ qs: { container: req.params.container, follow: true } }));
         streamServerEvents(req, res, logsSource, (item) => item.toString());

--- a/src/app/shared/services/workflows-service.ts
+++ b/src/app/shared/services/workflows-service.ts
@@ -24,8 +24,8 @@ export class WorkflowsService {
         });
     }
 
-    public getContainerLogs(nodeId: string, container: string): Observable<string> {
-        return requests.loadEventSource(`/logs/${nodeId}/${container}`).map((line) => {
+    public getContainerLogs(workflow: models.Workflow, nodeId: string, container: string): Observable<string> {
+        return requests.loadEventSource(`/logs/${workflow.metadata.namespace}/${nodeId}/${container}`).map((line) => {
             return line ? line + '\n' : line;
         });
     }

--- a/src/app/workflows/components/workflow-details/workflow-details.tsx
+++ b/src/app/workflows/components/workflow-details/workflow-details.tsx
@@ -113,7 +113,7 @@ class Component extends React.Component<Props, any> {
                     <SlidingPanel isShown={this.props.selectedNodeId && !!this.props.sidePanel} onClose={() => this.closeSidePanel()}>
                         {this.props.sidePanel && this.props.sidePanel.type === 'logs' && <LogsViewer source={{
                             key: this.props.sidePanel.nodeId,
-                            loadLogs: () => services.workflows.getContainerLogs(this.props.sidePanel.nodeId, this.props.sidePanel.container || 'main'),
+                            loadLogs: () => services.workflows.getContainerLogs(this.props.workflow, this.props.sidePanel.nodeId, this.props.sidePanel.container || 'main'),
                             shouldRepeat: () => this.props.workflow.status.nodes[this.props.sidePanel.nodeId].phase === 'Running',
                         }} />}
                         {this.props.sidePanel && this.props.sidePanel.type === 'yaml' && <WorkflowYamlViewer


### PR DESCRIPTION
Endpoint changes to include the namespace name as per the artifacts
endpoint. The code already used it but it wasn't provided by the route.

Closes argoproj/argo/issues#777