### PR TITLE
API server can filter workflows managed by specific workflow controller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ COPY  --from=build ./src/node_modules /app/node_modules
 WORKDIR /app
 
 EXPOSE 8001
-CMD node api/api/main.js --uiDist /app/app --inCluster ${IN_CLUSTER} --namespace ${ARGO_NAMESPACE} --enableWebConsole ${ENABLE_WEB_CONSOLE:-'false'} --uiBaseHref ${BASE_HREF:-'/'}
+CMD node api/api/main.js --uiDist /app/app --inCluster ${IN_CLUSTER} --namespace ${ARGO_NAMESPACE} --instanceId ${INSTANCE_ID} --enableWebConsole ${ENABLE_WEB_CONSOLE:-'false'} --uiBaseHref ${BASE_HREF:-'/'}

--- a/src/api/app.ts
+++ b/src/api/app.ts
@@ -50,12 +50,12 @@ export function create(
     app.get('/api/workflows', (req, res) => serve(res, async () => {
         let labelSelector: string[] = [];
         if (instanceId) {
-            labelSelector.push(`workflows.argoproj.io/controller-instanceid = ${instanceId}`)
+            labelSelector.push(`workflows.argoproj.io/controller-instanceid = ${instanceId}`);
         }
         if (req.query.phase) {
             let phases = req.query.phase instanceof Array ? req.query.phase : [req.query.phase];
             if (phases.length > 0) {
-                labelSelector.push(`workflows.argoproj.io/phase in (${phases.join(',')})`)
+                labelSelector.push(`workflows.argoproj.io/phase in (${phases.join(',')})`);
             }
         }
         const workflowList = await crd.workflows.get({

--- a/src/api/app.ts
+++ b/src/api/app.ts
@@ -36,6 +36,7 @@ export function create(
         uiBaseHref: string,
         inCluster: boolean,
         namespace: string,
+        instanceId: string,
         version,
         group = 'argoproj.io') {
     const config = Object.assign(
@@ -47,12 +48,18 @@ export function create(
     app.use(bodyParser.json({type: () => true}));
 
     app.get('/api/workflows', (req, res) => serve(res, async () => {
-        let phases: string[] = [];
+        let labelSelector: string[] = [];
+        if (instanceId) {
+            labelSelector.push(`workflows.argoproj.io/controller-instanceid = ${instanceId}`)
+        }
         if (req.query.phase) {
-            phases = req.query.phase instanceof Array ? req.query.phase : [req.query.phase];
+            let phases = req.query.phase instanceof Array ? req.query.phase : [req.query.phase];
+            if (phases.length > 0) {
+                labelSelector.push(`workflows.argoproj.io/phase in (${phases.join(',')})`)
+            }
         }
         const workflowList = await crd.workflows.get({
-            qs: {labelSelector: phases.length > 0 && `workflows.argoproj.io/phase in (${phases.join(',')})` || ''},
+            qs: { labelSelector: labelSelector.join(',') },
         }) as models.WorkflowList;
         workflowList.items.sort(
             (first, second) => moment(first.metadata.creationTimestamp) < moment(second.metadata.creationTimestamp) ? 1 : -1);

--- a/src/api/main.ts
+++ b/src/api/main.ts
@@ -11,5 +11,6 @@ app.create(
   argv.uiBaseHref || '/',
   argv.inCluster === 'true',
   argv.namespace || 'default',
+  argv.instanceId || undefined,
   argv.crdVersion || 'v1alpha1',
 ).listen(8001);


### PR DESCRIPTION
This PR resolves #6:
- Added API server parameter to set controller-instance value
- If `instanceId` is set, the `/api/workflows` endpoint will use additional label selector to limit the scope of listed workflows.