### PR TITLE
Fix argoproj link

### DIFF
--- a/src/app/help/components/help.tsx
+++ b/src/app/help/components/help.tsx
@@ -11,7 +11,7 @@ export const Help = () => (
                 <div className='help-box'>
                     <div className='help-box__ico help-box__ico--manual'/>
                     <h3>Documentation</h3>
-                    <a href='http://www.argoproj.github.io/' target='_blank' className='help-box__link'> Argo Project</a>
+                    <a href='https://argoproj.io/' target='_blank' className='help-box__link'> Argo Project</a>
                 </div>
             </div>
             <div className='columns large-4 medium-12'>

--- a/src/app/help/components/help.tsx
+++ b/src/app/help/components/help.tsx
@@ -11,7 +11,7 @@ export const Help = () => (
                 <div className='help-box'>
                     <div className='help-box__ico help-box__ico--manual'/>
                     <h3>Documentation</h3>
-                    <a href='http://www.argoproj.io/' target='_blank' className='help-box__link'> Argo Project</a>
+                    <a href='http://www.argoproj.github.io/' target='_blank' className='help-box__link'> Argo Project</a>
                 </div>
             </div>
             <div className='columns large-4 medium-12'>


### PR DESCRIPTION
This fixes the "Argo Project" link in the help screen. It previously directed to argoproj.io, which is down, so I changed it to the correct argoproj.github.io.