### PR TITLE
fixed 'X' not hiding under page when summary tab can scroll

### DIFF
--- a/src/app/workflows/components/workflow-details/workflow-details.scss
+++ b/src/app/workflows/components/workflow-details/workflow-details.scss
@@ -65,7 +65,7 @@
         cursor: pointer;
         top: 1em;
         right: -1em;
-        z-index: 11;
+        z-index: 8;
         border-radius: 50%;
         color: $argo-color-gray-5;
         font-size: 20px;


### PR DESCRIPTION
### Changed one line of code to make 'X' consistent with other divs

<img width="1440" alt="screen shot 2018-08-23 at 5 33 04 pm" src="https://user-images.githubusercontent.com/14003534/44558883-74b7ba00-a6fb-11e8-83ea-2cbb859d8b2e.png">
