### PR TITLE
force namespace isolation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ COPY  --from=build ./src/node_modules /app/node_modules
 WORKDIR /app
 
 EXPOSE 8001
-CMD node api/api/main.js --uiDist /app/app --inCluster ${IN_CLUSTER} --namespace ${ARGO_NAMESPACE} --instanceId ${INSTANCE_ID:-''} --enableWebConsole ${ENABLE_WEB_CONSOLE:-'false'} --uiBaseHref ${BASE_HREF:-'/'}
+CMD node api/api/main.js --uiDist /app/app --inCluster ${IN_CLUSTER} --namespace ${ARGO_NAMESPACE} --force-namespace-isolation ${FORCE_NAMESPACE_ISOLATION} --instanceId ${INSTANCE_ID:-''} --enableWebConsole ${ENABLE_WEB_CONSOLE:-'false'} --uiBaseHref ${BASE_HREF:-'/'}

--- a/src/api/main.ts
+++ b/src/api/main.ts
@@ -11,6 +11,7 @@ app.create(
   argv.uiBaseHref || '/',
   argv.inCluster === 'true',
   argv.namespace || 'default',
+  argv.forceNamespaceIsolation || 'false',
   argv.instanceId || undefined,
   argv.crdVersion || 'v1alpha1',
 ).listen(8001);

--- a/src/api/main.ts
+++ b/src/api/main.ts
@@ -11,7 +11,7 @@ app.create(
   argv.uiBaseHref || '/',
   argv.inCluster === 'true',
   argv.namespace || 'default',
-  argv.forceNamespaceIsolation || 'false',
+  argv.forceNamespaceIsolation === 'true',
   argv.instanceId || undefined,
   argv.crdVersion || 'v1alpha1',
 ).listen(8001);


### PR DESCRIPTION
Argo is capable of operating in a single namespace. 

If you deploy argo-ui the same way (without clusterrole/clusterrolebindings just normal role/rolebindings) workflows cannot be accessed.

I created an extra environment configuration option "FORCE_NAMESPACE_ISOLATION" to allow this to function on the UI for a singlenamespace.

Hopefully this will help others to use argo-ui in a single namespace

With kind regards,

Dennis Rutjes

