### PR TITLE
Add more logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
         "superagent-promise": "^1.1.0",
         "typescript": "^2.8.3",
         "winston": "^3.1.0",
+        "express-winston": "^3.0.0",
         "ws": "^4.0.0",
         "xterm": "2.4.0",
         "yamljs": "^0.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3282,6 +3282,13 @@ expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   dependencies:
     homedir-polyfill "^1.0.1"
 
+express-winston@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/express-winston/-/express-winston-3.0.0.tgz#4aaf495709bec875f81ae6c3fa99f550e4a544d9"
+  dependencies:
+    chalk "^2.4.1"
+    lodash "^4.17.10"
+
 express@^4.16.2, express@^4.16.3:
   version "4.16.3"
   resolved "https://registry.yarnpkg.com/express/-/express-4.16.3.tgz#6af8a502350db3246ecc4becf6b5a34d22f7ed53"


### PR DESCRIPTION
Adding express-winston turned out to be a pretty quick and easy way to add a bit more logging to the UI. I left the current error logging as is, but it might make sense to just remove it and use the error reporting that express-winston provides.