### PR TITLE
Fix pointer usage: from top-left to middle

### DIFF
--- a/src/app/workflows/components/workflow-dag/workflow-dag.scss
+++ b/src/app/workflows/components/workflow-dag/workflow-dag.scss
@@ -4,7 +4,6 @@
 
 .workflow-dag {
     position: relative;
-    overflow: hidden;
 
     &__line {
         position: absolute;
@@ -18,8 +17,9 @@
                         content: '\25BA';
                         position: absolute;
                         color: #A3A3A3;
-                        font-size: 10px;
-                        top: -10px;
+                        font-size: 12px;
+                        top: -9px;
+                        left: -1px;
                         transform: rotate(180deg);
                     }
                 }
@@ -29,7 +29,6 @@
     &__node {
         position: absolute;
         padding-left: 3.5em;
-        margin: 10px;
         box-shadow: 1px 1px 1px $argo-color-gray-4;
         background-color: white;
         border-radius: 4px;
@@ -44,6 +43,8 @@
             background-color: transparent;
             box-shadow: none;
             border: none;
+            padding-left: 0;
+
             &:after {
                 content: '';
                 position: absolute;
@@ -51,8 +52,9 @@
                 border-radius: 10px;
                 width: 20px;
                 height: 20px;
+                left: -10px;
+                top: -10px;
                 border: 1px dashed $argo-color-gray-5;
-                transform: translateX(24px) translateY(15px);
             }
 
             .workflow-dag__node-status, .workflow-dag__node-title {
@@ -79,7 +81,6 @@
         width: 3em;
         border-top-left-radius: 4px;
         border-bottom-left-radius: 4px;
-        line-height: 52px;
         text-align: center;
         color: white;
 
@@ -134,7 +135,6 @@
     }
 
     &__node-title {
-        line-height: 3em;
         overflow: hidden;
         white-space: nowrap;
         text-overflow: ellipsis;

--- a/src/app/workflows/components/workflow-dag/workflow-dag.tsx
+++ b/src/app/workflows/components/workflow-dag/workflow-dag.tsx
@@ -62,17 +62,21 @@ export class WorkflowDag extends React.Component<WorkflowDagProps> {
         });
         const size = this.getGraphSize(graph.nodes().map((id) => graph.node(id)));
         return (
-            <div className='workflow-dag' style={{width: size.width + 10, height: size.height + 100}}>
+            <div className='workflow-dag' style={{width: size.width, height: size.height}}>
                 {graph.nodes().map((id) => {
                     const node = graph.node(id) as models.NodeStatus & dagre.Node;
                     const shortName = Utils.shortNodeName(node);
                     return (
                         <div key={id}
                                 className={classNames('workflow-dag__node', {active: node.id === this.props.selectedNodeId, virtual: this.isVirtual(node)})}
-                                style={{left: node.x, top: node.y, width: node.width, height: node.height}}
+                                style={{left: (node.x - (node.width / 2)), top: (node.y - (node.height / 2)), width: node.width, height: node.height}}
                                 onClick={() => this.props.nodeClicked && this.props.nodeClicked(node)}>
-                            <div className={`workflow-dag__node-status workflow-dag__node-status--${node.phase.toLocaleLowerCase()}`}/>
-                            <div className='workflow-dag__node-title'>{shortName}</div>
+                            <div
+                                className={`workflow-dag__node-status workflow-dag__node-status--${node.phase.toLocaleLowerCase()}`}
+                                style={{lineHeight: NODE_HEIGHT + 'px'}}/>
+                            <div
+                                className='workflow-dag__node-title'
+                                style={{lineHeight: NODE_HEIGHT + 'px'}}>{shortName}</div>
                         </div>
                     );
                 })}
@@ -85,7 +89,7 @@ export class WorkflowDag extends React.Component<WorkflowDagProps> {
                         const angle = Math.atan2(line.y1 - line.y2, line.x1 - line.x2) * 180 / Math.PI;
                         return (
                             <div className={classNames('workflow-dag__line', {'workflow-dag__line--no-arrow': line.noArrow })} key={i}
-                                style={{ width: distance, left: xMid - (distance / 2), top: yMid, transform: `translate(100px, 35px) rotate(${angle}deg)`}} />
+                                style={{ width: distance, left: xMid - (distance / 2), top: yMid, transform: ` rotate(${angle}deg)`}} />
                         );
                     })}</div>
                 ))}
@@ -118,8 +122,8 @@ export class WorkflowDag extends React.Component<WorkflowDagProps> {
         let width = 0;
         let height = 0;
         nodes.forEach((node) => {
-            width = Math.max(node.x + node.width, width);
-            height = Math.max(node.y + node.height, height);
+            width = Math.max(node.x + (node.width / 2), width);
+            height = Math.max(node.y + (node.height / 2), height);
         });
         return {width, height};
     }

--- a/src/app/workflows/components/workflow-details/workflow-details.scss
+++ b/src/app/workflows/components/workflow-details/workflow-details.scss
@@ -44,7 +44,7 @@
         float: left;
 
         .workflow-dag {
-            margin: 1em auto;
+            margin: 3.5em auto;
         }
         .workflow-timeline {
             min-height: calc(100vh - 2 * #{$top-bar-height});


### PR DESCRIPTION
Hello!

While changing node size, I noticed that the values {x, y} returned by dagre are the center point of node/edge, as mentioned in [dagre wiki](https://github.com/dagrejs/dagre/wiki#output-graph):

> node, edge | x | For nodes, the x-coordinate for the center of the node. For edges the x-coordinate for the center of the edge label.
> 
> node, edge | y | For nodes, the y-coordinate for the center of the node. For edges the y-coordinate for the center of the edge label.

The code was using these values as top left point when positioning nodes. Some CSS translations and margins were added to correct those positioning, even though not necessary when top-left coordinates are properly calculated.

The translations were hard-coded to the currently used node width and height, making it impossible to change them without breaking the UI.

So I took the opportunity to create this PR changing the way that positions are calculated.

Hope it helps :)