### PR TITLE
fix: fix get logs api, get namespace from parameters instead of query

### DIFF
--- a/src/api/app.ts
+++ b/src/api/app.ts
@@ -122,7 +122,7 @@ export function create(
     });
 
     function getNamespace(req: express.Request) {
-        return forceNamespaceIsolation ? namespace : req.query.namespace;
+        return forceNamespaceIsolation ? namespace : (req.query.namespace || req.params.namespace);
     }
 
     function getWorkflow(ns: string, name: string): Promise<models.Workflow> {


### PR DESCRIPTION
Logs is not showing if workflow is in another namespace in argo-ui from v2.2.1