### PR TITLE
Allow to set arbitrary bind ip and port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ COPY  --from=build ./src/node_modules /app/node_modules
 WORKDIR /app
 
 EXPOSE 8001
-CMD node api/api/main.js --uiDist /app/app --inCluster ${IN_CLUSTER} --namespace ${ARGO_NAMESPACE} --force-namespace-isolation ${FORCE_NAMESPACE_ISOLATION} --instanceId ${INSTANCE_ID:-''} --enableWebConsole ${ENABLE_WEB_CONSOLE:-'false'} --uiBaseHref ${BASE_HREF:-'/'}
+CMD node api/api/main.js --uiDist /app/app --inCluster ${IN_CLUSTER} --namespace ${ARGO_NAMESPACE} --force-namespace-isolation ${FORCE_NAMESPACE_ISOLATION} --instanceId ${INSTANCE_ID:-''} --enableWebConsole ${ENABLE_WEB_CONSOLE:-'false'} --uiBaseHref ${BASE_HREF:-'/'} --ip ${IP:-'0.0.0.0'} --port ${PORT:-'8001'}

--- a/src/api/main.ts
+++ b/src/api/main.ts
@@ -6,6 +6,10 @@ import * as app from './app';
 
 const argv = yargs.argv;
 
+const ip = argv.ip || '0.0.0.0'
+const port = argv.port || '8001'
+console.log(`start argo-ui on ${argv.ip}:${argv.port}`)
+
 app.create(
   argv.uiDist || path.join(__dirname, '..', '..', 'dist', 'app'),
   argv.uiBaseHref || '/',
@@ -14,4 +18,4 @@ app.create(
   argv.forceNamespaceIsolation === 'true',
   argv.instanceId || undefined,
   argv.crdVersion || 'v1alpha1',
-).listen(8001);
+).listen(port, ip);


### PR DESCRIPTION
I wanted to run argo-ui in local docker with host network and still make it able to get workflows from remote Kubernetes cluster by the following command.

```
docker run --net host -v ~/.kube:/root/.kube -p 8001:8001 --name argo-ui --rm argoproj/argoui:v2.2.1
```

In this case, since we're not sure if the port `8001` is available in the host, we should allow users to change binding IP and port.