### PR TITLE
Always draw hidden items of dropdown

### DIFF
--- a/src/app/shared/components/dropdown/dropdown.tsx
+++ b/src/app/shared/components/dropdown/dropdown.tsx
@@ -32,10 +32,8 @@ export class DropDown extends React.Component<DropDownProps, DropDownState> {
     public render() {
         let children: React.ReactNode = null;
         if (typeof this.props.children === 'function') {
-            if (this.state.opened) {
-                const fun = this.props.children as () => React.ReactNode;
-                children = fun();
-            }
+            const fun = this.props.children as () => React.ReactNode;
+            children = fun();
         } else {
             children = this.props.children as React.ReactNode;
         }


### PR DESCRIPTION
The dropdown menu was not rendered inside the window like below when I first clicked the anchor.

<img width="1128" alt="Screen Shot 2019-07-15 at 12 03 59 PM" src="https://user-images.githubusercontent.com/1162120/61194843-3b1ae380-a6ff-11e9-9419-76009d537991.png">

If I clicked the anchor again, it was rendered inside.

I found the closed dropdown menu didn't have child elements and failed to get the size of them to correctly render the menu inside.