### PR TITLE
feat: Enable open application details in new tab on ctrl+click

### DIFF
--- a/src/components/navigation.ts
+++ b/src/components/navigation.ts
@@ -39,6 +39,8 @@ export class NavigationManager implements NavigationApi {
         options = options || {};
         if (options.event && options.event.metaKey) {
             window.open(path, '__target');
+        } else if (options.event && options.event.ctrlKey) {
+            window.open(path, '_blank');
         } else {
             if (options.replace) {
                 this.history.replace(path);


### PR DESCRIPTION
This enables to open application details from the application in a new browser tab, when CTRL was pressed on mouse click (just like browsers do with any other link).

Related to an issue reported in ArgoCD, https://github.com/argoproj/argo-cd/issues/3020