### PR TITLE
fix: Render `a` instead of `button` for links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,5 +2,5 @@
 Use the storybook to test components:
 
 ~~~
-yarn storybook
+yarn start
 ~~~

--- a/src/components/top-bar/top-bar.tsx
+++ b/src/components/top-bar/top-bar.tsx
@@ -21,6 +21,7 @@ export interface ActionMenu {
         title: string | React.ReactElement;
         iconClassName?: string;
         disabled?: boolean;
+        link?: string;
     }[];
 }
 
@@ -86,12 +87,23 @@ const renderBreadcrumbs = (breadcrumbs: { title: string, path?: string; }[]) => 
 
 const renderActionMenu = (actionMenu: ActionMenu) => (
     <div>
-        {actionMenu.items.map((item, i) => (
-            <button disabled={!!item.disabled} className='argo-button argo-button--base' onClick={() => item.action()} style={{marginRight: 2}} key={i}>
-                {item.iconClassName && (<i className={item.iconClassName} style={{marginLeft: '-5px', marginRight: '5px'}}/>)}
-                {item.title}
-            </button>
-        ))}
+        {actionMenu.items.map((item, i) => {
+            const children = (
+                <>
+                    {item.iconClassName && (<i className={item.iconClassName} style={{marginLeft: '-5px', marginRight: '5px'}}/>)}
+                    {item.title}
+                </>
+            );
+            return item.link ? (
+                <a href={item.link} className='argo-button argo-button--base' style={{marginRight: 2}} key={i}>
+                    {children}
+                </a>
+            ) : (
+                <button disabled={!!item.disabled} className='argo-button argo-button--base' onClick={() => item.action()} style={{marginRight: 2}} key={i}>
+                    {children}
+                </button>
+            );
+        })}
     </div>
 );
 

--- a/stories/page.tsx
+++ b/stories/page.tsx
@@ -42,6 +42,14 @@ const actionMenu = {
         action: () => {
             // do nothing
         },
+    },
+    {
+        title: 'New Item 5',
+        iconClassName: 'fa fa-link',
+        action: () => {
+            // do nothing
+        },
+        link: "/",
     }]
 };
 


### PR DESCRIPTION
As discussed [here](https://github.com/argoproj/argo/pull/2935#issuecomment-623282329), a better solution would be rendering a link instead of a button.