### PR TITLE
feat: Allow for default values to be set in popup forms (#3205)

### DIFF
--- a/src/components/popup/popup-manager.tsx
+++ b/src/components/popup/popup-manager.tsx
@@ -14,6 +14,7 @@ export interface PopupApi {
         },
         customIcon?: {name: string, color: string},
         titleColor?: string,
+        defaultValues?: {},
     ): Promise<FormValues>;
 }
 
@@ -57,6 +58,7 @@ export class PopupManager implements PopupApi {
         },
         customIcon?: { name: string, color: string },
         titleColor?: string,
+        defaultValues?: {},
     ): Promise<FormValues> {
         return new Promise((resolve) => {
             const closeAndResolve = (result: FormValues) => {
@@ -81,6 +83,7 @@ export class PopupManager implements PopupApi {
                 content: () => (
                     <Form
                         validateError={settings && settings.validate}
+                        defaultValues={defaultValues}
                         onSubmit={onSubmit}
                         getApi={(api) => formApi = api}>
                         {(api) => (

--- a/stories/popup.tsx
+++ b/stories/popup.tsx
@@ -2,6 +2,7 @@ import { Store, withState } from '@dump247/storybook-state';
 import { action } from '@storybook/addon-actions';
 import { storiesOf } from '@storybook/react';
 import * as React from 'react';
+import { Checkbox as ReactCheckbox} from 'react-form';
 import { Text } from 'react-form';
 
 import { Checkbox, FormField } from '../src/components';
@@ -216,6 +217,46 @@ storiesOf('Popup', module)
                             <p>This is another paragraph</p>
                         </div>
                         )
+                    );
+                    action('Prompt values')(values);
+                }}>Click me</button>
+            )}
+        </App>
+    )).add('prompt with React Checkbox that is checked by default; Username default set to admin', () => (
+        <App>
+            {(apis) => (
+                <button className='argo-button argo-button--base' onClick={async () => {
+                    const values = await apis.popup.prompt('Setting default values in popup example',
+                        (api) => (
+                            <React.Fragment>
+                                <div className='argo-form-row'>
+                                    <FormField label='Username' formApi={api} field='username' component={Text} />
+                                </div>
+                                <div className='argo-form-row'>
+                                    <FormField label='Password' formApi={api} field='password' component={Text} componentProps={{type: 'password'}} />
+                                </div>
+                                <div className='argo-form-row'>
+                                    <ReactCheckbox id='popup-react-checkbox' field='checkboxField'/> <label htmlFor='popup-react-checkbox'>This is a React Checkbox</label>
+                                </div>
+                            </React.Fragment>
+                        ),
+                        {
+                            validate: (vals) => ({
+                                username: !vals.username && 'Username is required',
+                                password: !vals.password && 'Password is required',
+                            }),
+                            submit: (vals, api, close) => {
+                                if (vals.username === 'admin' && vals.password === 'test') {
+                                    close();
+                                    action('Prompt values')(vals);
+                                } else {
+                                    api.setError('password', 'Username or password is invalid');
+                                }
+                            },    
+                        },
+                        undefined,
+                        undefined,
+                        {checkboxField: true, username: 'admin'},
                     );
                     action('Prompt values')(values);
                 }}>Click me</button>


### PR DESCRIPTION
Signed-off-by: Keith Chong <kykchong@redhat.com>

In general, this is to allow any popup form content to have default values pre-set by clients.  See the storybook entry.  Here, the username field default value is set to `admin` and the checkbox is checked by default, when the popup appears.  See screenshot:

![Screen Shot 2020-12-07 at 3 05 42 PM](https://user-images.githubusercontent.com/7726022/101400279-a938eb00-389e-11eb-9b27-9d4845e9c5f7.png)

Specifically, this is needed by https://github.com/argoproj/argo-cd/issues/3205.  The confirmation dialog will be changed to a prompt, with confirmation to delete by requiring users to enter the application name.  That way, the Cascade checkbox can remain checked by default.


(Commit message has wrong issue.  It should be https://github.com/argoproj/argo-cd/issues/3205 and not 4844)

