### PR TITLE
feat(ui): Update nav bar to better fit many icons and simplify design

### DIFF
--- a/src/components/nav-bar/nav-bar.scss
+++ b/src/components/nav-bar/nav-bar.scss
@@ -11,8 +11,7 @@ $nav-break-height-sm: 746px;
     padding-top: 160px;
     z-index: $nav-z-index;
     width: $nav-width;
-    background: linear-gradient(to bottom, #333, #444, #555, #666, #999);
-    box-shadow: inset -2px 0 4px 0 rgba(0,0,0,0.59);
+    background-color: $argo-color-gray-8;
 
     &__logo {
         position: absolute;
@@ -22,28 +21,28 @@ $nav-break-height-sm: 746px;
         padding: 8px 6px;
 
         img {
-            max-width: 104%;
+            display: block;
+            max-width: 85%;
+            margin: 0 auto;
         }
     }
 
     &__item {
         position: relative;
-        margin: 20px 0;
+        margin: 10px 0;
         padding-right: 3px;
-        font-size: 34px;
-        color: $white-color;
+        font-size: 25px;
         text-align: center;
         cursor: pointer;
+        color: $white-color;
         border-left: 3px solid transparent;
 
         &.active {
             border-color: $argo-color-teal-5;
         }
 
-        &:not(:hover):not(.active) i {
-            background: -webkit-gradient(linear, left top, left bottom, from(#bbb), to(#999));
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
+        &:hover {
+            color: $argo-color-gray-4;
         }
 
       &:focus {


### PR DESCRIPTION
With Argo Workflows UI v3, there are a lot of icons on the left - with the current size of the icons, they often don't all fit in the window, so this PR shrinks them slightly.

Additionally, I think simplifying the nav bar design a bit is a nice visual refresh and would give Workflows UI v3 an even clearer visual demarcation.

## Argo CD
<img width="303" alt="Screen Shot 2021-01-15 at 5 09 16 PM" src="https://user-images.githubusercontent.com/6250584/104792930-1f115b80-5755-11eb-873e-b80620f48112.png">

## Argo Workflows
<img width="205" alt="Screen Shot 2021-01-15 at 5 15 11 PM" src="https://user-images.githubusercontent.com/6250584/104792963-410ade00-5755-11eb-9b8f-1350a701d161.png">

