### PR TITLE
fix: autocomplete filter to make it case insensitive #5152

### DIFF
--- a/src/components/autocomplete/autocomplete.tsx
+++ b/src/components/autocomplete/autocomplete.tsx
@@ -103,7 +103,7 @@ export const Autocomplete = (props: AutocompleteProps) => {
             inputProps={props.inputProps}
             wrapperProps={wrapperProps}
             shouldItemRender={(item: AutocompleteOption, val: string) => {
-                return !props.filterSuggestions || item.label.includes(val);
+                return !props.filterSuggestions || item.label.toLowerCase().includes(val.toLowerCase());
             }}
             renderMenu={function(menuItems, _, style) {
                 if (menuItems.length === 0) {


### PR DESCRIPTION
For argoproj/argo-cd#[5152](https://github.com/argoproj/argo-cd/issues/5152)

Autocomplete filter has been made case insensitive

Signed-off-by: Ishita Sequeira isequeir@redhat.com