### PR TITLE
fix: data loader should return data if input has changed before observable returned first even

### DIFF
--- a/src/components/data-loader.tsx
+++ b/src/components/data-loader.tsx
@@ -89,11 +89,11 @@ export class DataLoader<D = {}, I = undefined> extends React.Component<LoaderPro
     }
 
     public reload() {
-        this.setState({ dataWrapper: null, error: false });
+        this.setState({ dataWrapper: null, error: false, inputChanged: true });
     }
 
     private async loadData() {
-        if (!this.state.error && !this.state.loading && (this.state.dataWrapper == null || this.state.inputChanged)) {
+        if (!this.state.error && !this.state.loading && this.state.dataWrapper == null || this.state.inputChanged) {
             this.setState({ error: false, loading: true, inputChanged: false, dataWrapper: this.props.noLoaderOnInputChange ? this.state.dataWrapper : null });
             try {
                 const res = 'input' in this.props ? this.props.load(this.props.input) : this.props.load();


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Another DataLoader bug fix: currently if data loader input changes before observable returns something it keep waiting forever. To reproduce:

* navigate to log viewer (e.g. https://cd.apps.argoproj.io/applications/argo-cd?node=%2FPod%2Fargocd%2Fargocd-redis-ha-haproxy-69c6df79c6-c9cfb%2F0&tab=logs) and enter a filter that does not match anything. 
* remove filter - loader keep waiting for results from previous request forewer 