### PR TITLE
fix: provide more visual cues for focused elements

### DIFF
--- a/src/styles/elements/buttons.scss
+++ b/src/styles/elements/buttons.scss
@@ -22,10 +22,18 @@
         &:hover {
             color: $argo-color-gray-6;
         }
+        
+        &:focus {
+            color: $argo-color-gray-6;
+        }
     }
 
     &:not(.disabled):not([disabled]) {
         &:hover {
+            background-color: #d1d5d9;
+        }
+
+        &:focus {
             background-color: #d1d5d9;
         }
     }
@@ -38,6 +46,12 @@
             &:hover {
                 color: $argo-color-gray-1;
                 background-color: $argo-color-gray-5;
+            }
+
+            &:focus {
+                color: $argo-color-gray-1;
+                background-color: $argo-color-gray-5;
+                border: 1px solid $argo-color-teal-5 !important;
             }
         }
 
@@ -59,6 +73,10 @@
             &:hover {
                 background-color: $argo-color-gray-3;
             }
+
+            &:focus {
+                background-color: $argo-color-gray-3;
+            }
         }
 
         &.disabled,
@@ -66,6 +84,10 @@
             color: $argo-color-gray-6;
 
             &:hover {
+                background-color: transparent;
+            }
+
+            &:focus {
                 background-color: transparent;
             }
         }
@@ -80,6 +102,11 @@
                 color: $argo-color-gray-1;
                 background-color:$argo-color-teal-6;
             }
+
+            &:focus {
+                color: $argo-color-gray-1;
+                background-color:$argo-color-teal-6;
+            }
         }
 
         &.disabled,
@@ -88,6 +115,10 @@
             box-shadow: inset 0 0 0 1px $argo-color-gray-4;
 
             &:hover {
+                color: $argo-color-gray-7;
+            }
+
+            &:focus {
                 color: $argo-color-gray-7;
             }
         }
@@ -164,8 +195,16 @@
             background: lighten($argo-color-teal-5, 10) !important;
         }
 
+        &:focus {
+            background: lighten($argo-color-teal-5, 10) !important;
+        }
+
         &:not(.disabled) {
             &:hover {
+                color: #fff;
+            }
+
+            &:focus {
                 color: #fff;
             }
         }
@@ -199,8 +238,14 @@
         color: #fff;
         background: linear-gradient(-58deg, #49505c 0%, #3f51b5 36%, #00c7d6 100%);
 
-        &:not(.disabled):hover {
-            color: #fff;
+        &:not(.disabled) {
+            &:hover {
+                color: #fff;
+            }
+
+            &:focus {
+                color: #fff;
+            }
         }
     }
 

--- a/src/styles/elements/form-controls.scss
+++ b/src/styles/elements/form-controls.scss
@@ -145,7 +145,6 @@
         position: absolute;
         width: 20px;
         height: 20px;
-        opacity: 0;
         cursor: pointer;
         top: 50%;
         transform: translateY(-50%);
@@ -176,6 +175,10 @@
                 display: block;
             }
         }
+
+        &:focus {
+            outline: 2px solid $argo-color-teal-5 !important;
+        } 
 
         &:disabled + span {
             background-color: $argo-color-gray-1;


### PR DESCRIPTION
This change would introduce visual cues when focus is applied to buttons and checkboxes.

Buttons when applied focus would behave the same way as when a user hovers over them and will also have a 1px teal border around them. (OK is focused below)

![Screenshot from 2021-03-12 15-26-45](https://user-images.githubusercontent.com/50851526/110995875-0a160a80-8349-11eb-944e-cf41b3640944.png)

Checkboxes would have a 2px teal outline when focused. 

![Screenshot from 2021-03-12 15-25-43](https://user-images.githubusercontent.com/50851526/110995906-19955380-8349-11eb-9417-9a65a30bf05a.png)