### PR TITLE
chore: Don't run release action on push to release branch, rather manually from GitHub

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,19 +1,19 @@
 name: Release NPM package
 
 on:
-  release:
-    types: [created]
-  push:
-    branches:
-      - 'master'
-      - 'release'
-      - 'release-*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Git tag to build release from
+        required: true
 
-jobs:    
-  publish-gpr:
+jobs:
+  publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.tag }}
       - uses: actions/setup-node@v1
         with:
           node-version: 12


### PR DESCRIPTION

Signed-off-by: Remington Breeze <remington@breeze.software>