### PR TITLE
Fix: prevent crash when Checkbox onChange is null

### DIFF
--- a/v2/components/checkbox/checkbox.tsx
+++ b/v2/components/checkbox/checkbox.tsx
@@ -47,7 +47,9 @@ export const CheckboxRow = (props: {value: boolean; onChange?: (value: boolean) 
             <Checkbox
                 onChange={(val) => {
                     setValue(val);
-                    props.onChange(val);
+                    if (props.onChange) {
+                        props.onChange(val);
+                    }
                 }}
                 value={value}
                 style={{


### PR DESCRIPTION
Signed-off-by: Remington Breeze <remington@breeze.software>