### PR TITLE
fix: prevent crash when autocomplete is fed array of nulls

### DIFF
--- a/v2/components/autocomplete/autocomplete.tsx
+++ b/v2/components/autocomplete/autocomplete.tsx
@@ -68,7 +68,10 @@ export const RenderAutocomplete = (
 
     React.useEffect(() => {
         const filtered = (props.items || []).filter((i) => {
-            return i.includes(debouncedVal);
+            if (i) {
+                return i.includes(debouncedVal);
+            }
+            return false;
         });
         setCurItems(filtered.length > 0 ? filtered : props.items);
     }, [debouncedVal, props.items]);


### PR DESCRIPTION
Signed-off-by: Remington Breeze <remington@breeze.software>