### PR TITLE
fix: autocomplete items should be hidden using display: none

### DIFF
--- a/v2/components/autocomplete/autocomplete.tsx
+++ b/v2/components/autocomplete/autocomplete.tsx
@@ -194,7 +194,7 @@ export const RenderAutocomplete = (
                 <ThemeDiv
                     className='autocomplete__items'
                     style={{
-                        visibility: !showSuggestions || (props.items || []).length < 1 ? 'hidden' : 'visible',
+                        display: !showSuggestions || (props.items || []).length < 1 ? 'none' : 'block',
                         top: position.top,
                         left: position.left,
                     }}


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

PR fixes minor visual glitch on safari:

![image](https://user-images.githubusercontent.com/426437/128943922-5c6bcd44-8ca4-466a-8ead-373587fc770b.png)
