### PR TITLE
fix: autocomplete should expand into right direction

### DIFF
--- a/v2/components/autocomplete/autocomplete.tsx
+++ b/v2/components/autocomplete/autocomplete.tsx
@@ -219,7 +219,8 @@ export const RenderAutocomplete = (
                 <ThemeDiv
                     className='autocomplete__items'
                     style={{
-                        display: !showSuggestions || (props.items || []).length < 1 ? 'none' : 'block',
+                        visibility: !showSuggestions || (props.items || []).length < 1 ? 'hidden' : 'visible',
+                        overflow: !showSuggestions || (props.items || []).length < 1 ? 'hidden' : null,
                         top: position.top,
                         left: position.left,
                     }}


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

PR https://github.com/argoproj/argo-ui/pull/123 fixed visual glitch in safari but introduced another bug: autocomplete unable to expand into right directory because hidden content has no height. PR fixes the glitch in another way.