### PR TITLE
fix: add suspended color for pie chart improvement #5200

### DIFF
--- a/src/styles/config.scss
+++ b/src/styles/config.scss
@@ -50,6 +50,7 @@ $argo-color-yellow: #FFD100;
 $argo-running-color-dark: #378398;
 $argo-running-color-light: #02C4D3;
 $argo-running-color: #0DADEA;
+$argo-suspended-color: #766F94;
 
 $argo-waiting-color-dark: $argo-color-gray-6;
 $argo-waiting-color-light: $argo-color-gray-5;


### PR DESCRIPTION
Signed-off-by: ciiay <yicai@redhat.com>

Fixes: #5200

This PR is for keeping colors consistent across the app. The new `suspended` color will be used in left border color in application list for both tile view and table view.