### PR TITLE
fix: logviewer long url incorrect line wrap when copying

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "react-toastify": "^5.0.1",
         "rxjs": "^6.6.6",
         "typescript": "^4.0.3",
-        "xterm": "2.4.0"
+        "xterm": "2.9.2"
     },
     "peerDependencies": {
         "react": "^16.9.3",

--- a/stories/index.stories.tsx
+++ b/stories/index.stories.tsx
@@ -1,6 +1,7 @@
 import './data-loader';
 import './dropdown';
 import './forms';
+import './logs-viewer';
 import './notifications';
 import './page';
 import './popup';

--- a/stories/logs-viewer.tsx
+++ b/stories/logs-viewer.tsx
@@ -1,0 +1,25 @@
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import { Observable } from 'rxjs';
+import { Observer } from 'rxjs';
+
+import { LogsViewer } from '../src/components';
+
+const url = "a-very-long-url/"
+
+const source = {
+    key: '1',
+    loadLogs: () => Observable.create(function(observer: Observer<string>) {
+        observer.next('http://' + url.repeat(50) +'\n');
+        observer.next('Hello World');
+        observer.complete();
+      }),
+    shouldRepeat: () => false
+}
+
+storiesOf('Logs Viewer', module)
+    .add('default', () => (
+        <div style={{height:'300px'}}>
+        <LogsViewer source={source} />
+        </div>
+    ));

--- a/yarn.lock
+++ b/yarn.lock
@@ -13725,9 +13725,10 @@ xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 
-xterm@2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/xterm/-/xterm-2.4.0.tgz#d70227993b74323e36495ab9c7bdee0bc8d0dbba"
+xterm@2.9.2:
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/xterm/-/xterm-2.9.2.tgz#ec3e7c636ba67af4a7026be2cff7bdf08e56400a"
+  integrity sha512-mdfPk9nY6WmKkMDIZUL6xVIpJoP6JLv3mQ2hA490e2DboUlTWt2f60cTnTT20ZYFU11mx9OgVCcqhDI7vOAQ5Q==
 
 y18n@^4.0.0:
   version "4.0.1"


### PR DESCRIPTION
fixes https://github.com/argoproj/argo-workflows/issues/6292

xterm version 2.9 fixes the issue.

There's an even newer version v3/v4+, in these versions,
they modified the Terminal interface, instead of taking in style class, they use js variable to define colours,
I couldn't find a way to make it reuse the common argo colour from css file without redefining them in js, thus didn't go with these versions.