### PR TITLE
feat(autocomplete): allow configure dropdown menu open on autocomplete

### DIFF
--- a/src/components/autocomplete/autocomplete.tsx
+++ b/src/components/autocomplete/autocomplete.tsx
@@ -23,6 +23,7 @@ export interface AutocompleteProps {
     autoCompleteRef?: (api: AutocompleteApi) => any;
     filterSuggestions?: boolean;
     qeid?: string;
+    open?: boolean;
 }
 
 export const Autocomplete = (props: AutocompleteProps) => {
@@ -122,6 +123,7 @@ export const Autocomplete = (props: AutocompleteProps) => {
             onChange={props.onChange}
             onSelect={props.onSelect}
             renderInput={props.renderInput}
+            open={props.open}
         />
     );
 };


### PR DESCRIPTION
"open" can override the internal logic which displays/hides the dropdown menu. 

Related PR https://github.com/argoproj/argo-workflows/pull/6776