### PR TITLE
fix: change prop type of abbreviations to Map

### DIFF
--- a/v2/components/autocomplete/autocomplete.tsx
+++ b/v2/components/autocomplete/autocomplete.tsx
@@ -23,7 +23,7 @@ export const useAutocomplete = (init: string): [string, SetInputFxn, Autocomplet
 export const Autocomplete = (
     props: React.InputHTMLAttributes<HTMLInputElement> & {
         items: string[];
-        abbreviations?: { [key: string]: string };
+        abbreviations?: Map<string, string>;
         inputStyle?: React.CSSProperties;
         onItemClick?: (item: string) => void;
         icon?: string;
@@ -40,7 +40,7 @@ export const Autocomplete = (
 export const RenderAutocomplete = (
     props: React.InputHTMLAttributes<HTMLInputElement> & {
         items: string[];
-        abbreviations?: { [key: string]: string };
+        abbreviations?: Map<string, string>;
         inputStyle?: React.CSSProperties;
         onItemClick?: (item: string) => void;
         icon?: string;
@@ -73,7 +73,7 @@ export const RenderAutocomplete = (
         const filtered = (props.items || []).filter((i) => {
             if (i) {
                 return props.abbreviations !== undefined
-                ? i.toLowerCase().includes(debouncedVal?.toLowerCase()) || props.abbreviations[i]?.includes(debouncedVal?.toLowerCase())
+                ? i.toLowerCase().includes(debouncedVal?.toLowerCase()) || props.abbreviations.get(i)?.includes(debouncedVal?.toLowerCase())
                 : i.toLowerCase().includes(debouncedVal?.toLowerCase());
             }
             return false;


### PR DESCRIPTION
Abbreviation prop type changed to reuse resources Map<> in argo-cd as per comment on https://github.com/argoproj/argo-cd/pull/7466 