### PR TITLE
fix: Trailing line in Filter Dropdown Menus #7821

### DIFF
--- a/src/components/autocomplete/autocomplete.scss
+++ b/src/components/autocomplete/autocomplete.scss
@@ -1,0 +1,7 @@
+.autocomplete {
+  &__items__item {
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+}

--- a/src/components/autocomplete/autocomplete.tsx
+++ b/src/components/autocomplete/autocomplete.tsx
@@ -2,6 +2,7 @@ import * as classNames from 'classnames';
 import * as React from 'react';
 import * as ReactAutocomplete from 'react-autocomplete';
 
+require('./autocomplete.scss');
 export interface AutocompleteApi {
     refresh(): any;
 }


### PR DESCRIPTION
Signed-off-by: ciiay yicai@redhat.com
Fixes: #7821

This PR is to remove bottom border on last item of a dropdown menu in Filter inputs.