### PR TITLE
fix(select): vertically center arrow

### DIFF
--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -24,7 +24,7 @@
     }
     
     &__value-arrow {
-        position: absolute;
+        // right most, vertically centered
         top: 50%;
         right: 0;
         transform: translateY(-50%);

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -25,8 +25,9 @@
     
     &__value-arrow {
         position: absolute;
-        top: 8px;
+        top: 50%;
         right: 0;
+        transform: translateY(-50%);
     }
     
     &__options {


### PR DESCRIPTION
fixes https://github.com/argoproj/argo-workflows/issues/7789

center align select arrow, fixes hidden arrow on no text selection


left(old) -> right(new)
argo-workflow:
![argo-workflow](https://user-images.githubusercontent.com/20961507/153403140-e444b66d-e630-4daa-bb9b-16c313f69ddc.PNG)

argo-cd:
![argocd](https://user-images.githubusercontent.com/20961507/153403151-86bac0a8-bcc2-4f06-8f64-041ba30aa084.PNG)


