### PR TITLE
feat: add optional prop closeOnEscape to sliding panel

### DIFF
--- a/src/components/sliding-panel/sliding-panel.tsx
+++ b/src/components/sliding-panel/sliding-panel.tsx
@@ -8,6 +8,7 @@ export interface SlidingPanelProps extends React.Props<any> {
     hasNoPadding?: boolean;
     offCanvas?: boolean;
     hasCloseButton?: boolean;
+    closeOnEscape?: boolean;
     header?: React.ReactNode;
     footer?: React.ReactNode;
     onClose?: () => any;
@@ -15,8 +16,22 @@ export interface SlidingPanelProps extends React.Props<any> {
 
 require('./sliding-panel.scss');
 
-export const SlidingPanel = (props: SlidingPanelProps) => (
-    <div className={classNames('sliding-panel', {
+export const SlidingPanel = (props: SlidingPanelProps) => {
+
+    const handler = (e: any) => {
+        if (e.key === 'Escape' && props.onClose) {
+            props.onClose();
+        }
+    };
+    React.useEffect(() => {
+        if (props.closeOnEscape) {
+            document.addEventListener('keydown', handler);
+            return () => document.removeEventListener('keydown', handler);
+        }
+    }, [props.closeOnEscape]);
+
+    return(
+       <div className={classNames('sliding-panel', {
         'sliding-panel--has-header': !!props.header,
         'sliding-panel--has-footer': !!props.footer,
         'sliding-panel--is-narrow': props.isNarrow,
@@ -47,4 +62,5 @@ export const SlidingPanel = (props: SlidingPanelProps) => (
         </div>
         <div className='sliding-panel__outside' onClick={() => props.onClose && props.onClose()}/>
     </div>
-);
+    );
+};


### PR DESCRIPTION
This and [Argo CD PR#8465](https://github.com/argoproj/argo-cd/pull/8465) would close [#8225](https://github.com/argoproj/argo-cd/issues/8225) in argocd. 

Adds additional optional prop `closeOnEscape` to the sliding panel, making closing sliding panels as easy as pressing the escape key. 