### PR TITLE
chore: update moment to avoid CVE-2022-24785

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "core-js": "^3.18.0",
         "foundation-sites": "^6.4.3",
         "history": "^4.7.2",
-        "moment": "2.29.2",
+        "moment": "^2.29.2",
         "moment-timezone": "^0.5.33",
         "portable-fetch": "^3.0.0",
         "prop-types": "^15.6.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "core-js": "^3.18.0",
         "foundation-sites": "^6.4.3",
         "history": "^4.7.2",
-        "moment": "^2.29.1",
+        "moment": "2.29.2",
         "moment-timezone": "^0.5.33",
         "portable-fetch": "^3.0.0",
         "prop-types": "^15.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11389,15 +11389,15 @@ moment-timezone@^0.5.33:
   dependencies:
     moment ">= 2.9.0"
 
-moment@2.29.2:
-  version "2.29.2"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.2.tgz#00910c60b20843bcba52d37d58c628b47b1f20e4"
-  integrity sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==
-
 "moment@>= 2.9.0", moment@^2.24.0, moment@^2.25.3:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+
+moment@^2.29.2:
+  version "2.29.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.2.tgz#00910c60b20843bcba52d37d58c628b47b1f20e4"
+  integrity sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==
 
 moo@^0.5.0:
   version "0.5.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11389,7 +11389,12 @@ moment-timezone@^0.5.33:
   dependencies:
     moment ">= 2.9.0"
 
-"moment@>= 2.9.0", moment@^2.24.0, moment@^2.25.3, moment@^2.29.1:
+moment@2.29.2:
+  version "2.29.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.2.tgz#00910c60b20843bcba52d37d58c628b47b1f20e4"
+  integrity sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==
+
+"moment@>= 2.9.0", moment@^2.24.0, moment@^2.25.3:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==


### PR DESCRIPTION
The directory traversal doesn't apply to us, since argo-ui is all client side. But it would be nice to clean up security scanner warnings.

There are still transitive dependencies on older versions, so I've opened PRs.

* https://github.com/ant-design/ant-design/pull/34867
* https://github.com/react-component/picker/pull/372

Once those are merged, we can update those depencencies.