### PR TITLE
feat: add regular font awesome icons

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -5,6 +5,7 @@
 @import 'node_modules/@fortawesome/fontawesome-free/scss/fontawesome';
 @import 'node_modules/@fortawesome/fontawesome-free/scss/solid';
 @import 'node_modules/@fortawesome/fontawesome-free/scss/brands';
+@import 'node_modules/@fortawesome/fontawesome-free/scss/regular';
 
 @include foundation-global-styles;
 @include foundation-flex-classes;


### PR DESCRIPTION
Upstream Issue - https://github.com/argoproj/argo-cd/issues/9026. Currently argo-ui doesn't support regular(outlined icons).

The implementation upstream would look like this (let me know if this is better than the current behaviour) -  
![star-icon](https://user-images.githubusercontent.com/17771352/163427385-d8df62d3-21c9-41e7-a15d-6ac95c5aef4b.png)

Signed-off-by: saumeya <saumeyakatyal@gmail.com>