### PR TITLE
fix: pin react-toastify

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "react-form": "^2.16.0",
         "react-helmet": "^6.1.0",
         "react-router-dom": "^4.2.2",
-        "react-toastify": "^9.0.8",
+        "react-toastify": "9.0.8",
         "rxjs": "^7.5.6",
         "typescript": "^4.8.3",
         "uuid": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6259,9 +6259,9 @@ cloneable-readable@^1.0.0:
     readable-stream "^2.3.5"
 
 clsx@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
-  integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
+  integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
 
 co@^4.6.0:
   version "4.6.0"
@@ -14751,7 +14751,7 @@ react-textarea-autosize@^8.3.0:
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
 
-react-toastify@^9.0.8:
+react-toastify@9.0.8:
   version "9.0.8"
   resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-9.0.8.tgz#3876c89fc6211a29027b3075010b5ec39ebe4f7e"
   integrity sha512-EwM+teWt49HSHx+67qI08yLAW1zAsBxCXLCsUfxHYv1W7/R3ZLhrqKalh7j+kjgPna1h5LQMSMwns4tB4ww2yQ==


### PR DESCRIPTION
It seems like from the time when https://github.com/argoproj/argo-ui/pull/367 was initially created, a newer
version of react-toastify was released, which looks like it pulls in
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464, which is a pretty breaking
change. I haven't looked in depth, but I suspect if we were to upgrade
to the latest version we'd need to upgrade React...