### PR TITLE
fix: add overflow to popup to make it scrollable

### DIFF
--- a/src/components/popup/popup.scss
+++ b/src/components/popup/popup.scss
@@ -23,6 +23,7 @@ $popup-border-radius: 8px;
         max-height: 600px;
         z-index: 20;
         border-radius: $popup-border-radius;
+        overflow: auto;
 
         &__header {
             line-height: 60px;


### PR DESCRIPTION
Fixes: https://github.com/argoproj/argo-workflows/issues/11448

**Before**:
<img width="1671" alt="Screenshot 2023-08-02 at 1 58 48 PM" src="https://github.com/argoproj/argo-ui/assets/25768124/b18c86f9-28f2-416c-9552-6177bee356f2">


**After**:
<img width="1728" alt="Screenshot 2023-08-02 at 1 58 15 PM" src="https://github.com/argoproj/argo-ui/assets/25768124/042352bf-9a95-438a-9bef-e16604ba1a36">


