### PR TITLE
[fix] make tooltip body persistent on hover

### DIFF
--- a/v2/components/tooltip/tooltip.stories.tsx
+++ b/v2/components/tooltip/tooltip.stories.tsx
@@ -9,9 +9,11 @@ export default {
 
 export const Primary = (args: any) => {
     return (
-        <Tooltip {...args} content={<Text>{args.content}</Text>}>
-            <Text>Hover over me!</Text>
-        </Tooltip>
+        <div style={{padding:'1em', width: 'fit-content'}}>
+            <Tooltip {...args} content={<Text>{args.content}</Text>}>
+                <Text>Hover over me!</Text>
+            </Tooltip>
+        </div>
     );
 };
 

--- a/v2/components/tooltip/tooltip.tsx
+++ b/v2/components/tooltip/tooltip.tsx
@@ -33,11 +33,11 @@ export const useHover = (): [React.MutableRefObject<any>, boolean] => {
 export const Tooltip = (props: {content: React.ReactNode | string; inverted?: boolean} & React.PropsWithRef<any>) => {
     const [tooltip, showTooltip] = useHover();
     return (
-        <div style={{position: 'relative', minWidth: 0}}>
+        <div ref={tooltip} style={{position: 'relative', minWidth: 0}}>
             <ThemeDiv hidden={!showTooltip} className={`tooltip ${props.inverted ? 'tooltip--inverted' : ''}`}>
                 {props.content}
             </ThemeDiv>
-            <div ref={tooltip}>{props.children}</div>
+            <div>{props.children}</div>
         </div>
     );
 };


### PR DESCRIPTION
includes the tooltip content inside the hover target, allowing users to hover the displayed values and copy/paste:

BEFORE
![2023-08-07 at 21 13](https://github.com/argoproj/argo-ui/assets/5599894/02919024-464d-4ab8-aada-c11bf6d2948d)

AFTER
![2023-08-07 at 21 11](https://github.com/argoproj/argo-ui/assets/5599894/de97d9d2-8c9e-4403-9eb9-42edb963736a)
