### PR TITLE
fix: dark mode improvements

### DIFF
--- a/src/components/popup/popup.scss
+++ b/src/components/popup/popup.scss
@@ -1,4 +1,5 @@
 @import '../../styles/config';
+@import '../../styles/theme';
 
 $popup-border-radius: 8px;
 
@@ -9,12 +10,17 @@ $popup-border-radius: 8px;
     width: 100%;
     height: 100%;
     z-index: 200;
+    // Just in case the theme class is not added
     background-color: rgba(222, 222, 222, 0.62); /*dim the background*/
-    border: 1px solid $argo-color-gray-4;
+    @include themify($themes) {
+        background-color: themed('overlay');        
+    }
 
     .popup-container {
         position: relative;
-        box-shadow: 3px 3px 20px #888888;
+        @include themify($themes) {
+            box-shadow: 3px 3px 20px themed('shadow');
+        }
         margin: 0 auto;
         top: 50%;
         transform: translateY(-50%);
@@ -47,7 +53,11 @@ $popup-border-radius: 8px;
             }
 
             &__normal {
+                // Just in case the theme class is not added
                 background-color: $argo-color-gray-2;
+                @include themify($themes) {
+                    background-color: themed('light-argo-gray-2');
+                }
             }
     
             &__red {
@@ -61,7 +71,11 @@ $popup-border-radius: 8px;
         }
 
         &__footer {
+            // Just in case the theme class is not added
             background-color: $argo-color-gray-1;
+            @include themify($themes) {
+                background-color: themed('background-2');        
+            }
             bottom: 0;
             padding-top: 20px;
             padding-left: 30px;
@@ -80,7 +94,11 @@ $popup-border-radius: 8px;
         }
 
         &__body {
+            // Just in case the theme class is not added
             background-color: $argo-color-gray-1;
+            @include themify($themes) {
+                background-color: themed('background-2');        
+            }
 
             &__hasNoIcon {
                 padding-left: 30px;
@@ -101,7 +119,12 @@ $popup-border-radius: 8px;
                 font-size: 15px;
                 margin-top: 10px;
                 margin-bottom: 10px;
+                // Just in case the theme class is not added
                 color: $argo-color-gray-6;
+
+                @include themify($themes) {
+                    color: themed('light-argo-gray-6');        
+                }
             }
         }
 

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -1,4 +1,5 @@
 @import '../../styles/config';
+@import '../../styles/theme';
 
 .select {
     position: relative;
@@ -15,12 +16,14 @@
         position: relative;
         padding: 8px 20px 8px 0;
         font-size: 15px;
-        border-bottom: 2px solid #ccc;
         transition: border .2s;
         cursor: pointer;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+        @include themify($themes) {      
+            border-bottom: 2px solid themed('border');;
+        }
     }
     
     &__value-arrow {

--- a/src/components/sliding-panel/sliding-panel.scss
+++ b/src/components/sliding-panel/sliding-panel.scss
@@ -103,8 +103,8 @@ $sliding-panel-middle-width: 600px;
         color: $argo-color-gray-5;
         @include themify($themes) {                  
             background-color: themed('light-argo-gray-2');
+            border-bottom: 1px solid themed('border');
         }
-        border-bottom: 1px solid #c6cfd1;
         font-weight: 500;
         font-size: .925em;
 

--- a/src/components/tabs/tabs.scss
+++ b/src/components/tabs/tabs.scss
@@ -57,6 +57,10 @@
             box-shadow: none;
             border-bottom: 1px solid $argo-color-gray-4;
 
+            .theme-dark & {
+                border-color: $argo-color-gray-7;
+            }
+
             a {
                 color: $argo-color-teal-5;
 

--- a/src/components/top-bar/top-bar.scss
+++ b/src/components/top-bar/top-bar.scss
@@ -5,10 +5,14 @@
 .top-bar {
     line-height: $top-bar-height;
     @include themify($themes) {
-        background: themed('background-2');        
+        background: themed('background-2');
     }
     transition: right .5s;
     border-bottom: 1px solid $argo-color-gray-2;
+
+    .theme-dark & {
+        border-color: $argo-color-gray-7;
+    }
 
     &__left-side {
         padding-left: 20px;

--- a/src/styles/elements/containers.scss
+++ b/src/styles/elements/containers.scss
@@ -95,11 +95,14 @@
                 color: themed('text-2');    
             }
             .columns {
-                border-bottom: 1px solid $argo-color-gray-3;
                 padding: 0;
                 vertical-align: middle;
                 line-height: 50px;
                 overflow-wrap: break-word;
+
+                @include themify($themes) {
+                    border-bottom: 1px solid themed('border');    
+                }
 
                 &--narrower-height {
                     line-height: 20px;

--- a/src/styles/elements/form-controls.scss
+++ b/src/styles/elements/form-controls.scss
@@ -74,9 +74,9 @@
     background-color: transparent;
     @include themify($themes) {                  
         color: themed('text-2');
+        border-bottom: 2px solid themed('border');;
     }
     border: 0;
-    border-bottom: 2px solid #ccc;
     transition: border .2s;
 
     .error & {

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -12,7 +12,10 @@ $themes: (
         light-argo-teal-7: $argo-color-teal-7,
         light-argo-teal-5: $argo-color-teal-5,
         pod-cyan: lightcyan,
-        layout-loader-bg: rgba($argo-color-gray-7, 0.4),  
+        layout-loader-bg: rgba($argo-color-gray-7, 0.4),
+        overlay: rgba(222, 222, 222, 0.62),
+        shadow: $argo-color-gray-5,
+        border: $argo-color-gray-3
     ),
     dark: (
         background-1: $dark-theme-background-1,
@@ -26,7 +29,9 @@ $themes: (
         light-argo-teal-5: $argo-color-teal-4,
         pod-cyan: $argo-color-teal-8,
         layout-loader-bg: rgba($argo-color-gray-3, 0.4),
-
+        overlay: rgba(70, 70, 70, 0.62),
+        shadow: $dark-theme-background-1,
+        border: $argo-color-gray-7
     )
 );
 


### PR DESCRIPTION
In this PR I've handled dark theme in the popup component and improved the colors of borders, text, and background that were too bright. 

Results in screenshots below. (it also needs some changes in Argo-CD repo)

Before
![Pasted Graphic 10](https://github.com/argoproj/argo-ui/assets/7262558/1005d180-7a33-4e5b-bda2-63ce2e76916b)

After
![Pasted Graphic 5](https://github.com/argoproj/argo-ui/assets/7262558/fd632766-b72e-4304-a17b-1361046408d9)

Before
![Pasted Graphic 11](https://github.com/argoproj/argo-ui/assets/7262558/245540b3-2a2f-473c-afa0-1dfbd8924c22)

After
![Pasted Graphic 6](https://github.com/argoproj/argo-ui/assets/7262558/8240111d-ce42-4513-818c-2fedc38df1b4)

Before
![Pasted Graphic 12](https://github.com/argoproj/argo-ui/assets/7262558/494a4020-7250-413d-8107-ece025174c4d)

After
![Pasted Graphic 7](https://github.com/argoproj/argo-ui/assets/7262558/fca0dd58-4121-437a-9b06-41707cbc4858)

Before
![Pasted Graphic 13](https://github.com/argoproj/argo-ui/assets/7262558/a4bc613e-5fc9-4717-8b98-5ffaf62a21ca)

After
![Pasted Graphic 8](https://github.com/argoproj/argo-ui/assets/7262558/7f196ead-4eb5-4275-bdad-983d41fc4102)

Before
![Pasted Graphic 14](https://github.com/argoproj/argo-ui/assets/7262558/46e073a2-0e6f-4db2-99f6-dc769262d08d)

After
![Pasted Graphic 9](https://github.com/argoproj/argo-ui/assets/7262558/fb351348-d5c9-45ed-8e0e-d69fb5ec5584)

