### PR TITLE
fix(deps): remove incorrectly duplicated peerDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,11 +44,8 @@
     },
     "peerDependencies": {
         "@types/react": "^16.8.5",
-        "antd": "^4.16.13",
-        "moment": "^2.29.1",
         "react": "^16.9.3",
-        "react-dom": "^16.9.3",
-        "rxjs": "^7.8.1"
+        "react-dom": "^16.9.3"
     },
     "devDependencies": {
         "@babel/core": "^7.21.3",


### PR DESCRIPTION
### Motivation

- these are all inside of prod `dependencies` already (it has to be either or)

- notably, `antd` had a version mismatch between `dependencies` and `peerDependencies` (and it was a major version difference, v5 vs v4 after #387)
  - `dependencies` supersede `peerDependencies` however, so the v5 dep was already used and the v4 dep was extraneous
  - see the [`yarn.lock` file](https://github.com/argoproj/argo-ui/blob/c65a9520366b0c0cf0ac585618d029e60041a94d/yarn.lock#L5124) as evidence, as well as a downstream `yarn.lock`, such as [Argo Workflows's](https://github.com/argoproj/argo-workflows/blob/93914261cff4216561c89c1f5f6123e7ad0d5f61/ui/yarn.lock#L2812)
    - note how this commit has no changes to the `yarn.lock` file either
  - this mismatch did cause install warnings downstream as well, which were impossible to resolve given this mismatch in `argo-ui`'s own deps
    - so those should now be resolved as well
    
Noticed this in https://github.com/argoproj/argo-workflows/pull/12097#discussion_r1375279098
    
### Modifications

Remove duplicate deps from `peerDependencies` in `package.json`

### Verification

No changes to `yarn.lock`, `yarn install`, build etc all still work fine. CI passes