### PR TITLE
docs: improve README with links and updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,33 +2,33 @@
 
 <img src="https://github.com/argoproj/argo-ui/blob/master/src/assets/images/logo.png?raw=true" alt="Argo Image" height="200px">
 
-Set of React components used by [Argo Workflows](https://github.com/argoproj/argo-workflows) and [Argo CD](https://github.com/argoproj/argo-cd).
+Set of React components used by [Argo Workflows](https://github.com/argoproj/argo-workflows), [Argo CD](https://github.com/argoproj/argo-cd), and [Argo Rollouts](https://github.com/argoproj/argo-rollouts).
 
 ## Build & Run
 
-1. Install Toolset: [NodeJS](https://nodejs.org/en/download/) and [Yarn](https://yarnpkg.com)
-1. Install Dependencies: From your command line, navigate to the argo-ui directory and run `yarn install` to install dependencies.
-1. Run: `yarn start` - starts https://storybook.js.org/ dev server
+1. Install Toolset: [NodeJS](https://nodejs.org/en/download/) and [Yarn v1](https://classic.yarnpkg.com/en/docs)
+1. Install Dependencies: run `yarn install`
+1. Run: `yarn start` - starts the [Storybook v6](https://storybook.js.org/docs/6.5/get-started/install) dev server
 
 ## Local Development
 
-To test your changes locally against Argo CD or another Argo project, we recommend using [yalc](https://github.com/wclr/yalc).
+To test your changes locally against Argo CD or another Argo project, we recommend using [`yalc`](https://github.com/wclr/yalc).
 
 First, install `yalc`:
 
-```
+```sh
 npm i -g yalc
 ```
 
 Next, in your local `argo-ui` directory, run
 
-```
+```sh
 yalc publish
 ```
 
 Finally, in your local `argo-cd/ui` directory, run
 
-```
+```sh
 yalc add argo-ui
 ```
 


### PR DESCRIPTION
### Motivation

The README is a bit dated -- particularly in its links to deps -- and could use some improvements

### Modifications

- Argo Rollouts also [uses this repo](https://github.com/argoproj/argo-rollouts/blob/db5e3b2a8ffd9aef8c1e2026985c906fc9eef068/ui/package.json#L11)

- update Yarn link to Yarn v1 / Classic, as those docs are quite different from the current v4 docs
- same for Storybook v6 vs current v7 / v8 beta
  - say "Storybook" with an in-line link, not just a link. it is referred to as "Storybook"
    - see also k8s style guide on [links](https://kubernetes.io/docs/contribute/style/style-guide/#links)

- <details> <summary>simplify "Build & Run" section a bit</summary>

  - changing dirs to the repo you just cloned is implied. we don't say how to clone or fork, so leave this out too
  - also you don't have to name your local dir `argo-ui`
  - "`yarn install` to install dependencies" is redundant
  - a bit simpler and more direct, [per k8s style guide](https://kubernetes.io/docs/contribute/style/style-guide/#use-simple-and-direct-language)
    - could make it even simpler, but left it close to the same style for now

</details>

- <details> <summary> fix some <code>markdownlint</code> etc issues in the "Local Development" section </summary>

  - specify syntax in code blocks
  - `yalc` should be in backticks as it's a command
  
 </details>
 
 ### Verification
 
 Docs-only change, see [rendered version](https://github.com/argoproj/argo-ui/blob/0c4d4144011cd9f7974a2410c386ce195e961cba/README.md) in this PR