### PR TITLE
fix: The navItems are not clickable with vimium (accessibility)

### DIFF
--- a/src/components/nav-bar/nav-bar.tsx
+++ b/src/components/nav-bar/nav-bar.tsx
@@ -35,10 +35,12 @@ export const NavBar: React.FunctionComponent<NavBarProps> = (props: NavBarProps,
                 <div className='nav-bar__version'>{props.version && props.version()}</div>
                 {(props.items || []).map((item) => (
                     <Tooltip content={item.title} placement='right' arrow={true} key={item.path + item.title}>
+                    <a href="#">
                         <div className={classNames('nav-bar__item', { active: isActiveRoute(locationPath, item.path) })}
                             onClick={() => context.router.history.push(item.path)}>
                             <i className={item.iconClassName}/>
                         </div>
+                    </a>
                     </Tooltip>
                 ))}
             </div>


### PR DESCRIPTION
## Motivation

- This PR adds a tag `role="checkbox"` to the navItems. This has the benefit that keyboard users can use vimium to navigate the user interface. At the moment, the navItems do not show up as links, because they do not contain a typical `<a href>`

- Adding `role="checkbox"` works around that issue, and makes them clickable

- Please also see the original issue: https://github.com/argoproj/argo-workflows/issues/12813