### PR TITLE
ci: only run Stale Action on specifically labeled issues and PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,7 +21,13 @@ jobs:
     - uses: actions/stale@v9
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
+        # timing
+        days-before-stale: 14 # 2 weeks of inactivity
+        days-before-close: 14 # 2 more weeks of inactivity
+        # labels to watch for, add, and remove
+        only-labels: 'problem/more information needed' # only mark issues/PRs as stale if they have this label
+        labels-to-remove-when-unstale: 'problem/more information needed' # remove label when unstale -- should be manually added back if information is insufficient
         stale-issue-message: 'Stale issue message'
         stale-pr-message: 'Stale pull request message'
-        stale-issue-label: 'no-issue-activity'
-        stale-pr-label: 'no-pr-activity'
+        stale-issue-label: 'problem/stale'
+        stale-pr-label: 'problem/stale'


### PR DESCRIPTION
### Motivation

- only run on issues labeled with "problem/more information needed"
  - same as done in Workflows https://github.com/argoproj/argo-workflows/pull/12488

- most issues and PRs are marked and closed as stale in this repo only because they've never been followed up on, not because they're missing information
  - for instance, a PR that never got a review or an issue with no maintainer response
    - this has happened to me many times too and it even happens on pinned issues like #453
      - and b/c of #453, this repo does not get much attention, which exacerbates the issue, resulting in closed PRs and issues that are actually still relevant 
  - we should only start the stale process for issues/PRs that need action from the contributor, not ones that need action from maintainers
    - same rationale as in Workflows https://github.com/argoproj/argo-workflows/pull/11836#issuecomment-1766672575, https://github.com/argoproj/argo-workflows/issues/11802#issuecomment-1720117452
    
### Modifications

- add `only-labels` configuration to check for the `problem/more information needed` label
  - and `labels-to-remove-when-unstale` to remove the same label when marked as no longer stale
  
- also use standard, categorized labels for `problem/stale` instead of `no-issue-activity` and `no-pr-activity`
  - same as Workflows https://github.com/argoproj/argo-workflows/pull/12789

- explicitly set the timelines for stale and close, matching Workflows

### Future Work

- will have a follow-up PR to standardize dependabot labels as well. **EDIT**: see #550 
- and one to fix formatting and OpenSSF Scorecard issues in this GH Workflow (action needs to be pinned, needs a top-level `permissions.contents: read`, etc). **EDIT**: see #551
  - this PR is very purpose specific