### PR TITLE
ci(deps): set labels and commit prefix for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,12 @@ updates:
       day: "saturday"
     # ignore all non-security updates: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit
     open-pull-requests-limit: 0
+    labels:
+      - type/dependencies
+      - javascript
+    commit-message:
+      prefix: chore(deps)
+      prefix-development: chore(deps-dev)
 
   # build / CI dependencies
   - package-ecosystem: "github-actions"
@@ -17,3 +23,8 @@ updates:
       day: "saturday"
     # ignore all non-security updates: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit
     open-pull-requests-limit: 0
+    labels:
+      - type/dependencies
+      - github_actions
+    commit-message:
+      prefix: chore(deps)


### PR DESCRIPTION
### Motivation

- use categorized labels, same as https://github.com/argoproj/argo-workflows/pull/12789
- follow our standard conventional commit prefixes for deps, same as https://github.com/argoproj/argo-workflows/pull/12881

### Modifications

- add `labels` and `commit-message` to `dependabot.yml`