### PR TITLE
refactor(ci): standardize Stale Action config

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,33 +1,41 @@
-# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
-#
-# You can adjust the behavior by modifying this file.
-# For more information, see:
 # https://github.com/actions/stale
 name: Mark stale issues and pull requests
 
 on:
   schedule:
-  - cron: '40 11 * * *'
+    - cron: '0 2 * * *' # once a day at 2am
+
+permissions:
+  contents: read
 
 jobs:
   stale:
-
-    runs-on: ubuntu-latest
     permissions:
-      issues: write
-      pull-requests: write
-
+      issues: write # for commenting on an issue and editing labels
+      pull-requests: write # for commenting on a PR and editing labels
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v9
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        # timing
-        days-before-stale: 14 # 2 weeks of inactivity
-        days-before-close: 14 # 2 more weeks of inactivity
-        # labels to watch for, add, and remove
-        only-labels: 'problem/more information needed' # only mark issues/PRs as stale if they have this label
-        labels-to-remove-when-unstale: 'problem/more information needed' # remove label when unstale -- should be manually added back if information is insufficient
-        stale-issue-message: 'Stale issue message'
-        stale-pr-message: 'Stale pull request message'
-        stale-issue-label: 'problem/stale'
-        stale-pr-label: 'problem/stale'
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          # timing
+          days-before-stale: 14 # 2 weeks of inactivity
+          days-before-close: 14 # 2 more weeks of inactivity
+          # labels to watch for, add, and remove
+          only-labels: 'problem/more information needed' # only mark issues/PRs as stale if they have this label
+          labels-to-remove-when-unstale: 'problem/more information needed' # remove label when unstale -- should be manually added back if information is insufficient
+          stale-issue-label: 'problem/stale'
+          stale-pr-label: 'problem/stale'
+          # automated messages to issue/PR authors
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had recent activity and needs more information.
+            It will be closed if no further activity occurs.
+          stale-pr-message: >
+            This PR has been automatically marked as stale because it has not had recent activity and needs further changes.
+            It will be closed if no further activity occurs.
+          close-issue-message: >
+            This issue has been closed due to inactivity and lack of information.
+            If you still encounter this issue, please add the requested information and re-open.
+          close-pr-message:
+            This PR has been closed due to inactivity and lack of changes.
+            If you would like to still work on this PR, please address the review comments and re-open.


### PR DESCRIPTION
### Motivation

- fix OpenSSF Scorecard issues
- have consistent settings here as in Workflows

### Modifications

- fix OpenSSF Scorecard issues
  - set top-level `permissions` to read-only
  - add comments for job-level `permissions`
  - pin action to a SHA

- use same settings [as Workflows](https://github.com/argoproj/argo-workflows/blob/b4af68bdd48c41bcf75ba433357c9b9b01a0e0c1/.github/workflows/stale.yaml)
  - with a dedicated `stale-issue-message` & `stale-pr-message`
  - same cron `schedule`
  - same formatting: indentionation and ordering etc
  
  
### Notes to Reviewers

This will merge conflict with #549 (due to indentation etc changes), so it is a draft for now