### PR TITLE
fix: `package.json:license` should be Apache

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "main": "./src/index.ts",
     "types": "./src/index.ts",
-    "license": "MIT",
+    "license": "Apache-2.0",
     "files": [
         "src",
         "v2",


### PR DESCRIPTION
### Motivation

- it was listed as `MIT` for some reason (copy+paste?), while Argo uses Apache, including this repo's own `LICENSE` file 
  - also CNCF uses Apache
  
### Modifications

- fix `package.json:license` field