### PR TITLE
fix: copy logs text on Linux & Windows. Fixes #557

### DIFF
--- a/src/components/logs-viewer/logs-viewer.tsx
+++ b/src/components/logs-viewer/logs-viewer.tsx
@@ -43,6 +43,16 @@ export class LogsViewer extends React.Component<LogsViewerProps> {
         this.terminal.loadAddon(this.fitAddon);
         this.terminal.open(container);
         this.fitAddon.fit();
+        // handle Ctrl+C for copying logs
+        this.terminal.attachCustomKeyEventHandler((ev) => {
+            if (ev.ctrlKey && ev.code === "KeyC" && ev.type === "keydown") {
+                const selection = this.terminal.getSelection();
+                if (!selection) return true;
+                
+                navigator.clipboard?.writeText(selection);
+                return false
+            }
+        });
     }
 
     public componentDidMount() {


### PR DESCRIPTION
Fixes #557

Inspired from https://github.com/xtermjs/xterm.js/issues/2478#issuecomment-1002371588 this `attachCustomKeyEventHandler` on the terminal catch the `Ctrl+C` event, and if there is a current text selection, we force the browser to copy that text.

