### PR TITLE
fix(select): right align arrow

### DIFF
--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -28,6 +28,7 @@
     
     &__value-arrow {
         // right most, vertically centered
+        position: absolute;
         top: 50%;
         right: 0;
         transform: translateY(-50%);


### PR DESCRIPTION
https://github.com/argoproj/argo-ui/pull/178
had `position: absolute;` in all the test
but not in the commit 🤯


Fixes https://github.com/argoproj/argo-ui/pull/178