### PR TITLE
fix(navigation): invalid redirection

### DIFF
--- a/src/components/navigation.ts
+++ b/src/components/navigation.ts
@@ -14,7 +14,9 @@ export class NavigationManager implements NavigationApi {
     }
 
     public goto(path: string, query: {[name: string]: any} = {}, options?: { event?: React.MouseEvent, replace?: boolean }): void {
-        if (path.startsWith('.')) {
+        if (path.startsWith('./') && this.history.location.pathname.endsWith('/')) {
+            path = this.history.location.pathname + path.slice(2);
+        } else if (path.startsWith('.')) {
             path = this.history.location.pathname + path.slice(1);
         }
         const noPathChange = path === this.history.location.pathname;


### PR DESCRIPTION
fix #564

When I discover applications on like `https://argocd.com/service/applications/`, search applications and then click it.
But it is redirected to `https://argocd.com/service/applications//{application-name}`.
And an empty page is shown.

for the soultion, the slash in the end has to be removed.