### PR TITLE
chore: remove unused Utils functions

### DIFF
--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -5,45 +5,6 @@ export function isPromise<T>(obj: any): obj is PromiseLike<T> {
 }
 
 export const Utils = {
-    getScrollParent(el: HTMLElement): HTMLElement {
-        const regex = /(auto|scroll)/;
-        while (el.parentNode) {
-            el = el.parentNode as HTMLElement;
-            const overflow = getComputedStyle(el, null).getPropertyValue('overflow') +
-            getComputedStyle(el, null).getPropertyValue('overflow-y') +
-            getComputedStyle(el, null).getPropertyValue('overflow-x');
-            if (regex.test(overflow)) {
-                return el;
-            }
-        }
-        return document.body;
-    },
-
-    scrollTo(element: HTMLElement, to: number, duration = 1000) {
-        function easeInOutQuad(t: number, b: number, c: number, d: number) {
-            t /= d / 2;
-            if (t < 1) {
-                return c / 2 * t * t + b;
-            }
-
-            t--;
-            return -c / 2 * ( t * ( t - 2 ) - 1) + b;
-        }
-        const start = element.scrollTop;
-        const change = to - start;
-        let currentTime = 0;
-        const increment = 20;
-
-        const animateScroll = () => {
-            currentTime += increment;
-            element.scrollTop = easeInOutQuad(currentTime, start, change, duration);
-            if (currentTime < duration) {
-                setTimeout(animateScroll, increment);
-            }
-        };
-        animateScroll();
-    },
-
     toObservable<T>(val: T | Observable<T> | Promise<T>): Observable<T> {
         const observable = val as Observable<T>;
         if (observable && observable.subscribe && observable.forEach) {


### PR DESCRIPTION
### Motivation

Clean up unused code

### Modifications

- remove unused functions `getScrollParent` and `scrollTo` from `utils.ts`

### Verification

- in this repo they are unused:
  - https://github.com/search?q=repo%3Aargoproj%2Fargo-ui%20getScrollParent&type=code
  - https://github.com/search?q=repo%3Aargoproj%2Fargo-ui+scrollTo&type=code

- in CD they are not used:
  - https://github.com/search?q=repo%3Aargoproj%2Fargo-cd+getScrollParent&type=code
  - https://github.com/search?q=repo%3Aargoproj%2Fargo-cd+scrollTo&type=code

- in Rollouts they are not used:
  - https://github.com/search?q=repo%3Aargoproj%2Fargo-rollouts+getScrollParent&type=code
  - https://github.com/search?q=repo%3Aargoproj%2Fargo-rollouts+scrollTo&type=code

- in Workflows they are not used:
  - https://github.com/search?q=repo%3Aargoproj%2Fargo-workflows+getScrollParent&type=code
  - https://github.com/search?q=repo%3Aargoproj%2Fargo-workflows+scrollTo&type=code