### PR TITLE
fix!: remove deprecated `durationMs` prop

### DIFF
--- a/src/components/duration.tsx
+++ b/src/components/duration.tsx
@@ -6,8 +6,7 @@ import { formatDuration } from '../../v2';
  * Output a string duration from a number of seconds
  *
  * @param {number} props.durationS - The number of seconds.
- * @param {number} props.durationMs - The number of seconds. DEPRECATED: The "Ms" suffix is incorrect, use props.durationS instead.
  */
-export function Duration(props: {durationMs: number, durationS: number}) {
-    return <span>{formatDuration(props.durationMs || props.durationS, 2)}</span>;
+export function Duration(props: {durationS: number}) {
+    return <span>{formatDuration(props.durationS, 2)}</span>;
 }


### PR DESCRIPTION
Follow-up to https://github.com/argoproj/argo-ui/pull/535#issuecomment-2151143975, fixes the issue I discovered in https://github.com/argoproj/argo-cd/pull/19655#issuecomment-2305897525

### Motivation

I previously left in `durationMs` for backward-compatibility so that you could use either, but I forgot to mark the types as optional, so both ended up being required by the typings, oops 🙃 

### Modifications

Instead of making them both confusingly optional (no way of doing "one of"), just remove the deprecated `durationMs` in another breaking change