### PR TITLE
fix: prevent double slashes in path handling - NavigationManager.goto…

### DIFF
--- a/src/components/navigation.ts
+++ b/src/components/navigation.ts
@@ -15,7 +15,12 @@ export class NavigationManager implements NavigationApi {
 
     public goto(path: string, query: {[name: string]: any} = {}, options?: { event?: React.MouseEvent, replace?: boolean }): void {
         if (path.startsWith('.')) {
-            path = this.history.location.pathname + path.slice(1);
+            if (this.history.location.pathname.endsWith('/') && path.startsWith('./')) {
+                // Prevent ending up with two slashes - e.g. my-argo.test/applications//my-app
+                path = this.history.location.pathname + path.slice(2);
+            } else {
+                path = this.history.location.pathname + path.slice(1);
+            }
         }
         const noPathChange = path === this.history.location.pathname;
         const params = noPathChange ? new URLSearchParams(this.history.location.search) : new URLSearchParams();


### PR DESCRIPTION
This PR attempts fix duplicate slashes in path handling in the `NavigationManager.goto` method.

I encountered a case where the `Search applications...` form in ArgoCD would display some suggested apps - if I click on an app, it leads me to `www.example.com/applications//my-apps` which leads to nothing being loaded on the page except the sidebar.