### PR TITLE
fix: prevent double slashes in path handling - NavigationManager.goto

### DIFF
--- a/src/components/navigation.ts
+++ b/src/components/navigation.ts
@@ -14,7 +14,10 @@ export class NavigationManager implements NavigationApi {
     }
 
     public goto(path: string, query: {[name: string]: any} = {}, options?: { event?: React.MouseEvent, replace?: boolean }): void {
-        if (path.startsWith('.')) {
+        if (this.history.location.pathname.endsWith('/') && path.startsWith('./')) {
+            // Prevent ending up with two slashes - e.g. my-argo.test/applications//my-app
+            path = this.history.location.pathname + path.slice(2);
+        } else {
             path = this.history.location.pathname + path.slice(1);
         }
         const noPathChange = path === this.history.location.pathname;


### PR DESCRIPTION
This PR attempts fix duplicate slashes in path handling in the `NavigationManager.goto` method.

I encountered a case where the `Search applications...` form in ArgoCD would display some suggested apps - if I click on an app, it leads me to `www.example.com/applications//my-apps` which leads to nothing being loaded on the page except the sidebar.

- Adjusted the `NavigationManager.goto` method to handle redirection to `./` paths when the current URL ends with a slash - to avoid ending up with duplicate slashes in the URL

Signed-off-by: Arman Ossi Loko armanossiloko@gmail.com