### PR TITLE
fix: add missing glob prop to Autocomplete to match RenderAutocomplete

### DIFF
--- a/v2/components/autocomplete/autocomplete.tsx
+++ b/v2/components/autocomplete/autocomplete.tsx
@@ -21,21 +21,21 @@ export const useAutocomplete = (init: string): [string, SetInputFxn, Autocomplet
     return [state, setState, autocomplete];
 };
 
-export const Autocomplete = (
-    props: React.InputHTMLAttributes<HTMLInputElement> & {
-        items: string[];
-        abbreviations?: Map<string, string>;
-        inputStyle?: React.CSSProperties;
-        onItemClick?: (item: string) => void;
-        icon?: string;
-        inputref?: React.MutableRefObject<HTMLInputElement>;
-        value: string;
-        onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
-        className?: string;
-        style?: React.CSSProperties;
-        glob?: boolean | IOptions;
-    }
-) => {
+type Props = React.InputHTMLAttributes<HTMLInputElement> & {
+    items: string[];
+    abbreviations?: Map<string, string>;
+    inputStyle?: React.CSSProperties;
+    onItemClick?: (item: string) => void;
+    icon?: string;
+    inputref?: React.MutableRefObject<HTMLInputElement>;
+    value: string;
+    onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    className?: string;
+    style?: React.CSSProperties;
+    glob?: boolean | IOptions;
+};
+
+export const Autocomplete = (props: Props) => {
     return (
         <KeybindingProvider>
             <RenderAutocomplete {...props} />
@@ -43,21 +43,7 @@ export const Autocomplete = (
     );
 };
 
-export const RenderAutocomplete = (
-    props: React.InputHTMLAttributes<HTMLInputElement> & {
-        items: string[];
-        abbreviations?: Map<string, string>;
-        inputStyle?: React.CSSProperties;
-        onItemClick?: (item: string) => void;
-        icon?: string;
-        inputref?: React.MutableRefObject<HTMLInputElement>;
-        value: string;
-        onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
-        className?: string;
-        style?: React.CSSProperties;
-        glob?: boolean | IOptions;
-    }
-) => {
+export const RenderAutocomplete = (props: Props) => {
     const [curItems, setCurItems] = React.useState(props.items || []);
     const nullInputRef = React.useRef<HTMLInputElement>(null);
     const inputRef = props.inputref || nullInputRef;


### PR DESCRIPTION
Fixes #593

Just noticed that `glob` wasn’t passed to `Autocomplete`, so this PR adds it and also extracts a shared prop type for consistency.  
Apologies for the oversight — I’ll be more careful with similar updates going forward!

### Summary
Adds `glob?: boolean | IOptions` to the Autocomplete component to align with RenderAutocomplete.

### Context
In a previously [merged PR](https://github.com/argoproj/argo-ui/pull/594) that introduced `glob` support for `RenderAutocomplete`, the same option was unintentionally omitted from `Autocomplete`.  
This PR addresses that omission.

### Changes
- Add `glob?: boolean | IOptions` to `Autocomplete` props to match `RenderAutocomplete`
- Extract a shared props type `AutocompleteComponentProps` and use it in both components (no behavior change)