### PR TITLE
fix: close button position in confirm popup

### DIFF
--- a/src/components/popup/popup-manager.tsx
+++ b/src/components/popup/popup-manager.tsx
@@ -46,7 +46,7 @@ export class PopupManager implements PopupApi {
 
             this.popupPropsSubject.next({
                 title: (
-                    <span style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}><div>{title}</div> <i className='argo-icon-close' onClick={() => closeAndResolve(false)}/></span>
+                    <span style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', width: '100%' }}><div>{title}</div> <i className='argo-icon-close' onClick={() => closeAndResolve(false)}/></span>
                 ),
                 content,
                 footer: (


### PR DESCRIPTION
Closes #605 

As described in the issue, the close button should be consistent across all popups. The close button, which was previously shifted toward the left, has been aligned to the right by adding `width: 100%`, matching the layout used in the prompt popup.

<img width="1045" height="528" alt="confirm-popup-ui-fix" src="https://github.com/user-attachments/assets/0a136fb0-39a8-4a7c-9bd2-fe3f8a6d71e6" />
