### PR TITLE
fix: add hover/focus background to special button

### DIFF
--- a/src/styles/elements/buttons.scss
+++ b/src/styles/elements/buttons.scss
@@ -240,10 +240,12 @@
         &:not(.disabled) {
             &:hover {
                 color: #fff;
+                background: $argo-color-teal-6 !important;
             }
 
             &:focus {
                 color: #fff;
+                background: $argo-color-teal-6 !important;
             }
         }
     }


### PR DESCRIPTION
Related to argoproj/argo-cd#27794

The `argo-button--special` variant only sets `color: #fff` on `hover`/`focus` but does not change the background color, unlike other button variants.

### Before
Hover changes background to gray with white text as you can see in the original issue.


### After
Hover lightens the existing teal background.

https://github.com/user-attachments/assets/52c09dc9-ecb4-40a2-8a5a-dbae0f935d4f