### PR TITLE
fix: prevent checkbox label overlap

### DIFF
--- a/src/styles/elements/form-controls.scss
+++ b/src/styles/elements/form-controls.scss
@@ -132,6 +132,20 @@
     color: $argo-color-teal-6;
 }
 
+// Checkbox: render label inline beside the checkbox instead of using the
+// floating-label grid, which would otherwise overlap the checkbox.
+.argo-field-container:has(> .argo-checkbox) {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+
+    > label.argo-label-placeholder {
+        transform: none;
+        cursor: pointer;
+        pointer-events: auto;
+    }
+}
+
 .argo-field {
     // Hide autofill background
     &:-webkit-autofill {


### PR DESCRIPTION
Fixes argoproj/argo-cd#27974

Adds a CSS rule so that when `FormField` wraps a `Checkbox`, the floating-label grid layout is replaced with an inline flex layout.
All consumers using `<FormField component={CheckboxField} label="..." />` will be fixed by this including checkboxes across Add Sync Window, Connect Repo, and more.

<img width="686" height="486" alt="스크린샷 2026-05-24 오전 9 28 29" src="https://github.com/user-attachments/assets/7f9dd722-3bbc-41e9-85d5-66ca107a0163" />
