### PR TITLE
fix(form): mirror state writes to refs synchronously in compat layer

### DIFF
--- a/src/components/form/compat.test.tsx
+++ b/src/components/form/compat.test.tsx
@@ -308,4 +308,25 @@ describe('touched state', () => {
         await userEvent.click(screen.getByText('Submit'));
         expect(await screen.findByText('required')).toBeInTheDocument();
     });
+
+    test('26: setValue followed by submitForm in the same handler sees the updated value', async () => {
+        const onSubmit = jest.fn();
+        let capturedApi!: FormApi;
+        render(
+            <Form
+                defaultValues={{id: undefined as number | undefined}}
+                onSubmit={onSubmit}
+                getApi={(api) => { capturedApi = api; }}>
+                {() => <span>form</span>}
+            </Form>
+        );
+        // Repro for the sync-window-edit regression: the panel sets `id` then
+        // submits synchronously. The submit handler must see the new id, not
+        // the stale (undefined) one from the previous render.
+        act(() => {
+            capturedApi.setValue('id', 42);
+            capturedApi.submitForm(null);
+        });
+        expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({id: 42}), null, expect.any(Object));
+    });
 });

--- a/src/components/form/compat.tsx
+++ b/src/components/form/compat.tsx
@@ -292,48 +292,72 @@ export function Form(props: FormProps) {
         }
     }, []);
 
+    // Writes update refs synchronously in addition to scheduling React state updates,
+    // so callers that read `api.values` immediately after `api.setValue(...)` within
+    // the same event handler see the new value. This matches the original react-form,
+    // which used a synchronous reducer.
     const proxiedApi = React.useMemo<FormApi>(() => ({
         get values() {
             return valuesRef.current;
         },
         set values(nextValues: FormValues) {
+            valuesRef.current = nextValues;
             setValues(nextValues);
         },
         get touched() {
             return touchedRef.current;
         },
         set touched(nextTouched: Record<string, any>) {
+            touchedRef.current = nextTouched;
             setTouched(nextTouched);
         },
         get errors() {
             return errorsRef.current;
         },
         set errors(nextErrors: FormErrors) {
+            errorsRef.current = nextErrors;
             setErrors(nextErrors);
         },
         submitForm,
         setError(field: Path, error: any) {
-            setErrors((current) => deepSet(current, field, error));
+            errorsRef.current = deepSet(errorsRef.current, field, error);
+            setErrors(errorsRef.current);
         },
         getFormState(): FormState {
             return {values: valuesRef.current, touched: touchedRef.current, errors: errorsRef.current};
         },
         setFormState(state: Partial<FormState>) {
-            if (state.values !== undefined) setValues(state.values);
-            if (state.touched !== undefined) setTouched(state.touched);
-            if (state.errors !== undefined) setErrors(state.errors);
+            if (state.values !== undefined) {
+                valuesRef.current = state.values;
+                setValues(state.values);
+            }
+            if (state.touched !== undefined) {
+                touchedRef.current = state.touched;
+                setTouched(state.touched);
+            }
+            if (state.errors !== undefined) {
+                errorsRef.current = state.errors;
+                setErrors(state.errors);
+            }
         },
         setAllValues(nextValues: FormValues) {
+            valuesRef.current = nextValues;
             setValues(nextValues);
         },
         setValue(field: Path, value: any) {
-            setValues((prev) => deepSet(prev, field, value));
-            setTouched((prev) => deepSet(prev, field, true));
+            valuesRef.current = deepSet(valuesRef.current, field, value);
+            touchedRef.current = deepSet(touchedRef.current, field, true);
+            setValues(valuesRef.current);
+            setTouched(touchedRef.current);
         },
         setTouched(field: Path, isTouched: boolean) {
-            setTouched((prev) => deepSet(prev, field, isTouched));
+            touchedRef.current = deepSet(touchedRef.current, field, isTouched);
+            setTouched(touchedRef.current);
         },
         resetAll() {
+            valuesRef.current = defaultValuesRef.current;
+            touchedRef.current = {};
+            errorsRef.current = {};
             setValues(defaultValuesRef.current);
             setErrors({});
             setTouched({});


### PR DESCRIPTION
Each setter (setValue, setAllValues, setError, setTouched, setFormState, resetAll, and the proxy setters on values/touched/errors) now updates valuesRef.current / touchedRef.current / errorsRef.current synchronously in addition to scheduling the React state update. This fixes an issue where, if a consumer reads the form state in the same handler as they set state, they will end up reading stale values.