### PR TITLE
Fix deprecation warnings in argo-ui

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     },
     "dependencies": {
         "@fortawesome/fontawesome-free": "^6.2.1",
-        "@tippy.js/react": "^3.1.1",
         "classnames": "^2.2.6",
         "core-js": "^3.32.1",
         "downshift": "^9.3.2",
@@ -33,6 +32,7 @@
         "prop-types": "^15.8.1",
         "react-toastify": "11.1.0",
         "rxjs": "^7.8.1",
+        "tippy.js": "5.2.1",
         "typescript": "^4.9.5",
         "uuid": "^9.0.0",
         "xterm": "^4.19.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,9 +16,6 @@ importers:
       '@fortawesome/fontawesome-free':
         specifier: ^6.2.1
         version: 6.7.2
-      '@tippy.js/react':
-        specifier: ^3.1.1
-        version: 3.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       classnames:
         specifier: ^2.2.6
         version: 2.5.1
@@ -46,6 +43,9 @@ importers:
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
+      tippy.js:
+        specifier: 5.2.1
+        version: 5.2.1
       typescript:
         specifier: ^4.9.5
         version: 4.9.5
@@ -1057,13 +1057,6 @@ packages:
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
-
-  '@tippy.js/react@3.1.1':
-    resolution: {integrity: sha512-KF45vW/jKh/nBXk/2zzTFslv/T46zOMkIoDJ56ymZ+M00yHttk58J5wZ29oqGqDIUnobWSZD+cFpbR4u/UUvgw==}
-    deprecated: This package has moved to @tippyjs/react (the same but without a dot in the scoped organization) due to issues some shells had with the dot when installing the package.
-    peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
 
   '@tootallnate/once@1.1.2':
     resolution: {integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==}
@@ -5916,13 +5909,6 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
-  '@tippy.js/react@3.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
-    dependencies:
-      prop-types: 15.8.1
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      tippy.js: 5.2.1
-
   '@tootallnate/once@1.1.2': {}
 
   '@tootallnate/once@2.0.1': {}
@@ -8221,7 +8207,7 @@ snapshots:
       jest-environment-jsdom: 26.6.2
       jest-environment-node: 26.6.2
       jest-get-type: 26.3.0
-      jest-jasmine2: 26.6.3(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@14.11.2)(typescript@4.9.5))
+      jest-jasmine2: 26.6.3
       jest-regex-util: 26.0.0
       jest-resolve: 26.6.2
       jest-util: 26.6.2
@@ -8301,7 +8287,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jest-jasmine2@26.6.3(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@14.11.2)(typescript@4.9.5)):
+  jest-jasmine2@26.6.3:
     dependencies:
       '@babel/traverse': 7.29.0
       '@jest/environment': 26.6.2
@@ -8322,11 +8308,7 @@ snapshots:
       pretty-format: 26.6.2
       throat: 5.0.0
     transitivePeerDependencies:
-      - bufferutil
-      - canvas
       - supports-color
-      - ts-node
-      - utf-8-validate
 
   jest-leak-detector@26.6.2:
     dependencies:

--- a/src/components/tooltip/tooltip.test.tsx
+++ b/src/components/tooltip/tooltip.test.tsx
@@ -101,6 +101,21 @@ describe('Tooltip', () => {
         errorSpy.mockRestore();
     });
 
+    test('omits optional props entirely from the tippy() options object when the caller does not pass them', () => {
+        render(
+            <Tooltip content='hi'>
+                <span>target</span>
+            </Tooltip>
+        );
+
+        const tippyMock = jest.requireMock('tippy.js').default;
+        const options = tippyMock.mock.calls[tippyMock.mock.calls.length - 1][1];
+
+        ['placement', 'zIndex', 'popperOptions', 'arrow', 'allowHTML', 'duration', 'hideOnClick'].forEach(key => {
+            expect(Object.keys(options)).not.toContain(key);
+        });
+    });
+
     test('shows tooltip content on hover and hides on unhover', async () => {
         render(
             <Tooltip content='tooltip text'>

--- a/src/components/tooltip/tooltip.test.tsx
+++ b/src/components/tooltip/tooltip.test.tsx
@@ -11,7 +11,12 @@ jest.mock('tippy.js', () => {
             contentNode.textContent = options.content;
         }
 
+        let isEnabled = true;
+
         const show = () => {
+            if (!isEnabled) {
+                return;
+            }
             if (!document.body.contains(contentNode)) {
                 document.body.appendChild(contentNode);
             }
@@ -22,16 +27,52 @@ jest.mock('tippy.js', () => {
             }
         };
 
+        const clickHide = () => {
+            if (options.hideOnClick === false) {
+                return;
+            }
+            hide();
+        };
+
         target.addEventListener('mouseenter', show);
         target.addEventListener('mouseleave', hide);
+        target.addEventListener('click', clickHide);
+
+        const tooltipBox = document.createElement('div');
+        tooltipBox.className = 'tippy-tooltip';
 
         const instance = {
             destroy: jest.fn(() => {
                 hide();
                 target.removeEventListener('mouseenter', show);
                 target.removeEventListener('mouseleave', hide);
-            })
+                target.removeEventListener('click', clickHide);
+            }),
+            show: jest.fn((duration?: number) => {
+                void duration;
+                show();
+            }),
+            hide: jest.fn((duration?: number) => {
+                void duration;
+                if (document.body.contains(contentNode)) {
+                    document.body.removeChild(contentNode);
+                }
+            }),
+            enable: jest.fn(() => {
+                isEnabled = true;
+            }),
+            disable: jest.fn(() => {
+                isEnabled = false;
+                if (document.body.contains(contentNode)) {
+                    document.body.removeChild(contentNode);
+                }
+            }),
+            popperChildren: {tooltip: tooltipBox}
         };
+
+        if (typeof options.onCreate === 'function') {
+            options.onCreate(instance);
+        }
 
         return instance;
     });
@@ -200,5 +241,109 @@ describe('Tooltip', () => {
 
         const tippyMock = jest.requireMock('tippy.js').default;
         expect(tippyMock).toHaveBeenCalledWith(received.node, expect.anything());
+    });
+
+    test('enabled={false} suppresses the tooltip from showing on hover', async () => {
+        render(
+            <Tooltip content='tooltip text' enabled={false}>
+                <span>hover me</span>
+            </Tooltip>
+        );
+
+        const tippyMock = jest.requireMock('tippy.js').default;
+        const instance = tippyMock.mock.results[tippyMock.mock.results.length - 1].value;
+        expect(instance.disable).toHaveBeenCalled();
+
+        await userEvent.hover(screen.getByText('hover me'));
+        expect(screen.queryByText('tooltip text')).not.toBeInTheDocument();
+    });
+
+    test('toggling enabled back to true re-enables the tooltip', async () => {
+        const {rerender} = render(
+            <Tooltip content='tooltip text' enabled={false}>
+                <span>hover me</span>
+            </Tooltip>
+        );
+
+        rerender(
+            <Tooltip content='tooltip text' enabled={true}>
+                <span>hover me</span>
+            </Tooltip>
+        );
+
+        const tippyMock = jest.requireMock('tippy.js').default;
+        const instance = tippyMock.mock.results[tippyMock.mock.results.length - 1].value;
+        expect(instance.enable).toHaveBeenCalled();
+
+        await userEvent.hover(screen.getByText('hover me'));
+        await waitFor(() => expect(screen.getByText('tooltip text')).toBeInTheDocument());
+    });
+
+    test('hideOnClick={false} keeps the tooltip visible after a click on the trigger', async () => {
+        render(
+            <Tooltip content='Copied!' hideOnClick={false}>
+                <span>click me</span>
+            </Tooltip>
+        );
+
+        const target = screen.getByText('click me');
+
+        await userEvent.hover(target);
+        await waitFor(() => expect(screen.getByText('Copied!')).toBeInTheDocument());
+
+        await userEvent.click(target);
+        expect(screen.getByText('Copied!')).toBeInTheDocument();
+    });
+
+    test('passes allowHTML, duration, and hideOnClick straight through to tippy()', () => {
+        render(
+            <Tooltip content='x' allowHTML={true} duration={200} hideOnClick={false}>
+                <span>target</span>
+            </Tooltip>
+        );
+
+        const tippyMock = jest.requireMock('tippy.js').default;
+        expect(tippyMock).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({
+                allowHTML: true,
+                duration: 200,
+                hideOnClick: false
+            })
+        );
+    });
+
+    test('className is applied to the tippy popper box via onCreate', () => {
+        render(
+            <Tooltip content='x' className='custom-tooltip'>
+                <span>target</span>
+            </Tooltip>
+        );
+
+        const tippyMock = jest.requireMock('tippy.js').default;
+        const instance = tippyMock.mock.results[tippyMock.mock.results.length - 1].value;
+
+        expect(instance.popperChildren.tooltip.classList.contains('custom-tooltip')).toBe(true);
+    });
+
+    test('visible={true} calls instance.show(duration) and visible={false} calls instance.hide(duration)', () => {
+        const {rerender} = render(
+            <Tooltip content='x' visible={false} duration={150}>
+                <span>target</span>
+            </Tooltip>
+        );
+
+        const tippyMock = jest.requireMock('tippy.js').default;
+        const instance = tippyMock.mock.results[tippyMock.mock.results.length - 1].value;
+
+        expect(instance.hide).toHaveBeenCalledWith(150);
+
+        rerender(
+            <Tooltip content='x' visible={true} duration={150}>
+                <span>target</span>
+            </Tooltip>
+        );
+
+        expect(instance.show).toHaveBeenCalledWith(150);
     });
 });

--- a/src/components/tooltip/tooltip.test.tsx
+++ b/src/components/tooltip/tooltip.test.tsx
@@ -41,7 +41,15 @@ jest.mock('tippy.js', () => {
         const tooltipBox = document.createElement('div');
         tooltipBox.className = 'tippy-tooltip';
 
+        let currentProps = {...options};
+
         const instance = {
+            setProps: jest.fn((partialProps: any) => {
+                currentProps = {...currentProps, ...partialProps};
+            }),
+            get props() {
+                return currentProps;
+            },
             destroy: jest.fn(() => {
                 hide();
                 target.removeEventListener('mouseenter', show);
@@ -360,5 +368,98 @@ describe('Tooltip', () => {
         );
 
         expect(instance.show).toHaveBeenCalledWith(150);
+    });
+
+    test('a prop change updates the existing tippy instance instead of destroying and recreating it', () => {
+        const tippyMock = jest.requireMock('tippy.js').default;
+        tippyMock.mockClear();
+
+        const {rerender} = render(
+            <Tooltip content='x' placement='top' popperOptions={{modifiers: {hide: {enabled: false}}}}>
+                <span>target</span>
+            </Tooltip>
+        );
+
+        expect(tippyMock).toHaveBeenCalledTimes(1);
+        const instance = tippyMock.mock.results[0].value;
+
+        rerender(
+            <Tooltip content='x' placement='bottom' popperOptions={{modifiers: {hide: {enabled: false}}}}>
+                <span>target</span>
+            </Tooltip>
+        );
+
+        expect(tippyMock).toHaveBeenCalledTimes(1);
+        expect(instance.destroy).not.toHaveBeenCalled();
+        expect(instance.setProps).toHaveBeenCalledWith(expect.objectContaining({placement: 'bottom'}));
+    });
+
+    test('setProps omits optional props the caller did not pass, so tippy defaults are preserved', () => {
+        const {rerender} = render(
+            <Tooltip content='x' theme='light'>
+                <span>target</span>
+            </Tooltip>
+        );
+
+        const tippyMock = jest.requireMock('tippy.js').default;
+        const instance = tippyMock.mock.results[tippyMock.mock.results.length - 1].value;
+
+        rerender(
+            <Tooltip content='x' theme='dark'>
+                <span>target</span>
+            </Tooltip>
+        );
+
+        const partialProps = instance.setProps.mock.calls[instance.setProps.mock.calls.length - 1][0];
+        ['placement', 'zIndex', 'popperOptions', 'arrow', 'allowHTML', 'duration', 'hideOnClick'].forEach(key => {
+            expect(Object.keys(partialProps)).not.toContain(key);
+        });
+    });
+
+    test('enabled={false} survives an unrelated prop change', async () => {
+        const {rerender} = render(
+            <Tooltip content='tooltip text' enabled={false} placement='top'>
+                <span>hover me</span>
+            </Tooltip>
+        );
+
+        const tippyMock = jest.requireMock('tippy.js').default;
+        const instance = tippyMock.mock.results[tippyMock.mock.results.length - 1].value;
+
+        rerender(
+            <Tooltip content='tooltip text' enabled={false} placement='bottom'>
+                <span>hover me</span>
+            </Tooltip>
+        );
+
+        expect(instance.enable).not.toHaveBeenCalled();
+
+        await userEvent.hover(screen.getByText('hover me'));
+        expect(screen.queryByText('tooltip text')).not.toBeInTheDocument();
+    });
+
+    test('a className change removes the old class and adds the new one', () => {
+        const {rerender} = render(
+            <Tooltip content='x' className='old-class shared-class'>
+                <span>target</span>
+            </Tooltip>
+        );
+
+        const tippyMock = jest.requireMock('tippy.js').default;
+        const instance = tippyMock.mock.results[tippyMock.mock.results.length - 1].value;
+        const box = instance.popperChildren.tooltip;
+
+        expect(box.classList.contains('old-class')).toBe(true);
+
+        rerender(
+            <Tooltip content='x' className='new-class shared-class'>
+                <span>target</span>
+            </Tooltip>
+        );
+
+        expect(box.classList.contains('old-class')).toBe(false);
+        expect(box.classList.contains('new-class')).toBe(true);
+        expect(box.classList.contains('shared-class')).toBe(true);
+        expect(box.classList.contains('tippy-tooltip')).toBe(true);
     });
 });

--- a/src/components/tooltip/tooltip.test.tsx
+++ b/src/components/tooltip/tooltip.test.tsx
@@ -1,0 +1,204 @@
+import * as React from 'react';
+import {render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import {Tooltip} from './tooltip';
+
+jest.mock('tippy.js', () => {
+    const tippy = jest.fn((target: Element, options: any) => {
+        const contentNode: Element = typeof options.content === 'string' ? document.createElement('div') : options.content;
+        if (typeof options.content === 'string') {
+            contentNode.textContent = options.content;
+        }
+
+        const show = () => {
+            if (!document.body.contains(contentNode)) {
+                document.body.appendChild(contentNode);
+            }
+        };
+        const hide = () => {
+            if (document.body.contains(contentNode)) {
+                document.body.removeChild(contentNode);
+            }
+        };
+
+        target.addEventListener('mouseenter', show);
+        target.addEventListener('mouseleave', hide);
+
+        const instance = {
+            destroy: jest.fn(() => {
+                hide();
+                target.removeEventListener('mouseenter', show);
+                target.removeEventListener('mouseleave', hide);
+            })
+        };
+
+        return instance;
+    });
+
+    return {__esModule: true, default: tippy};
+});
+
+describe('Tooltip', () => {
+    test('renders and unmounts in StrictMode without React 19 element.ref warnings', async () => {
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        const {unmount} = render(
+            <React.StrictMode>
+                <Tooltip content='hello'>
+                    <span>target</span>
+                </Tooltip>
+            </React.StrictMode>
+        );
+
+        await userEvent.hover(screen.getByText('target'));
+        unmount();
+
+        const badCall = errorSpy.mock.calls.find(call => call.some(arg => typeof arg === 'string' && (arg.includes('element.ref') || arg.includes('React 19'))));
+        expect(badCall).toBeUndefined();
+
+        errorSpy.mockRestore();
+    });
+
+    test('shows tooltip content on hover and hides on unhover', async () => {
+        render(
+            <Tooltip content='tooltip text'>
+                <span>hover me</span>
+            </Tooltip>
+        );
+
+        const target = screen.getByText('hover me');
+
+        await userEvent.hover(target);
+        await waitFor(() => expect(screen.getByText('tooltip text')).toBeInTheDocument());
+
+        await userEvent.unhover(target);
+        await waitFor(() => expect(screen.queryByText('tooltip text')).not.toBeInTheDocument());
+    });
+
+    test('accepts JSX content, not just strings', async () => {
+        render(
+            <Tooltip
+                content={
+                    <div className='custom-tooltip'>
+                        <strong>bold</strong> content
+                    </div>
+                }>
+                <span>hover me</span>
+            </Tooltip>
+        );
+
+        await userEvent.hover(screen.getByText('hover me'));
+        await waitFor(() => expect(screen.getByText('bold')).toBeInTheDocument());
+    });
+
+    test('passes placement, zIndex, and popperOptions straight through to tippy()', () => {
+        const popperOptions = {
+            modifiers: {
+                preventOverflow: {enabled: true},
+                hide: {enabled: false}
+            }
+        };
+
+        render(
+            <Tooltip content='x' placement='bottom' zIndex={9999} popperOptions={popperOptions}>
+                <span>target</span>
+            </Tooltip>
+        );
+
+        const tippyMock = jest.requireMock('tippy.js').default;
+        expect(tippyMock).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({
+                placement: 'bottom',
+                zIndex: 9999,
+                popperOptions
+            })
+        );
+    });
+
+    test('passes interactive, theme, appendTo, animation, and arrow straight through to tippy(), with defaults when omitted', () => {
+        render(
+            <Tooltip content='x'>
+                <span>defaults</span>
+            </Tooltip>
+        );
+
+        const tippyMock = jest.requireMock('tippy.js').default;
+        expect(tippyMock).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({
+                interactive: true,
+                theme: 'light',
+                appendTo: document.body,
+                animation: 'fade'
+            })
+        );
+
+        const container = document.createElement('div');
+        render(
+            <Tooltip content='x' interactive={false} theme='dark' appendTo={container} animation='shift-away' arrow={true}>
+                <span>overrides</span>
+            </Tooltip>
+        );
+
+        expect(tippyMock).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({
+                interactive: false,
+                theme: 'dark',
+                appendTo: container,
+                animation: 'shift-away',
+                arrow: true
+            })
+        );
+    });
+
+    test('calls the tippy instance destroy() on unmount', () => {
+        const {unmount} = render(
+            <Tooltip content='x'>
+                <span>target</span>
+            </Tooltip>
+        );
+
+        const tippyMock = jest.requireMock('tippy.js').default;
+        const instance = tippyMock.mock.results[tippyMock.mock.results.length - 1].value;
+
+        unmount();
+
+        expect(instance.destroy).toHaveBeenCalledTimes(1);
+    });
+
+    test('a child with its own forwardRef still receives the underlying DOM node', () => {
+        const received: {node: HTMLElement | null} = {node: null};
+
+        const Target = React.forwardRef<HTMLSpanElement>(function Target(_props, ref) {
+            const localRef = React.useCallback(
+                (node: HTMLSpanElement | null) => {
+                    received.node = node;
+                    if (typeof ref === 'function') {
+                        ref(node);
+                    } else if (ref) {
+                        (ref as React.MutableRefObject<HTMLSpanElement | null>).current = node;
+                    }
+                },
+                [ref]
+            );
+            return <span ref={localRef}>target</span>;
+        });
+
+        const outerRef = React.createRef<HTMLSpanElement>();
+
+        render(
+            <Tooltip content='x'>
+                <Target ref={outerRef} />
+            </Tooltip>
+        );
+
+        expect(received.node).not.toBeNull();
+        expect(received.node).toBe(screen.getByText('target'));
+
+        const tippyMock = jest.requireMock('tippy.js').default;
+        expect(tippyMock).toHaveBeenCalledWith(received.node, expect.anything());
+    });
+});

--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -23,10 +23,33 @@ export interface TooltipProps {
     appendTo?: Element | ((ref: Element) => Element);
     animation?: string;
     arrow?: boolean;
+    enabled?: boolean;
+    visible?: boolean;
+    duration?: number;
+    allowHTML?: boolean;
+    className?: string;
+    hideOnClick?: boolean;
     children: React.ReactElement;
 }
 
-export const Tooltip = ({content, popperOptions, zIndex, placement, interactive = true, theme = 'light', appendTo = document.body, animation = 'fade', arrow, children}: TooltipProps) => {
+export const Tooltip = ({
+    content,
+    popperOptions,
+    zIndex,
+    placement,
+    interactive = true,
+    theme = 'light',
+    appendTo = document.body,
+    animation = 'fade',
+    arrow,
+    enabled = true,
+    visible,
+    duration,
+    allowHTML,
+    className,
+    hideOnClick,
+    children
+}: TooltipProps) => {
     const child = React.Children.only(children) as React.ReactElement<{ref?: React.Ref<Element>}>;
     const [target, setTarget] = React.useState<Element | null>(null);
     const instanceRef = React.useRef<Instance | null>(null);
@@ -59,7 +82,15 @@ export const Tooltip = ({content, popperOptions, zIndex, placement, interactive 
             placement,
             zIndex,
             popperOptions,
-            arrow
+            arrow,
+            allowHTML,
+            duration,
+            hideOnClick,
+            onCreate(createdInstance: Instance) {
+                if (className) {
+                    createdInstance.popperChildren.tooltip.classList.add(...className.split(' ').filter(Boolean));
+                }
+            }
         });
         instanceRef.current = instance;
 
@@ -70,13 +101,35 @@ export const Tooltip = ({content, popperOptions, zIndex, placement, interactive 
             queueMicrotask(() => reactRoot.unmount());
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [target, placement, interactive, zIndex, popperOptions, theme, appendTo, animation, arrow]);
+    }, [target, placement, interactive, zIndex, popperOptions, theme, appendTo, animation, arrow, allowHTML, duration, hideOnClick, className]);
 
     React.useEffect(() => {
         if (reactRootRef.current) {
             reactRootRef.current.render(content);
         }
     }, [content]);
+
+    React.useEffect(() => {
+        if (!instanceRef.current) {
+            return;
+        }
+        if (enabled) {
+            instanceRef.current.enable();
+        } else {
+            instanceRef.current.disable();
+        }
+    }, [target, enabled]);
+
+    React.useEffect(() => {
+        if (!instanceRef.current || visible === undefined) {
+            return;
+        }
+        if (visible) {
+            instanceRef.current.show(duration);
+        } else {
+            instanceRef.current.hide(duration);
+        }
+    }, [target, visible, duration]);
 
     return React.cloneElement(child, {ref: setRef});
 };

--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -79,13 +79,13 @@ export const Tooltip = ({
             appendTo,
             animation,
             interactive,
-            placement,
-            zIndex,
-            popperOptions,
-            arrow,
-            allowHTML,
-            duration,
-            hideOnClick,
+            ...(placement !== undefined ? {placement} : {}),
+            ...(zIndex !== undefined ? {zIndex} : {}),
+            ...(popperOptions !== undefined ? {popperOptions} : {}),
+            ...(arrow !== undefined ? {arrow} : {}),
+            ...(allowHTML !== undefined ? {allowHTML} : {}),
+            ...(duration !== undefined ? {duration} : {}),
+            ...(hideOnClick !== undefined ? {hideOnClick} : {}),
             onCreate(createdInstance: Instance) {
                 if (className) {
                     createdInstance.popperChildren.tooltip.classList.add(...className.split(' ').filter(Boolean));

--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -54,6 +54,7 @@ export const Tooltip = ({
     const [target, setTarget] = React.useState<Element | null>(null);
     const instanceRef = React.useRef<Instance | null>(null);
     const reactRootRef = React.useRef<ReactDOM.Root | null>(null);
+    const appliedClassNamesRef = React.useRef<string[]>([]);
 
     const setRef = React.useCallback(
         (node: Element | null) => {
@@ -87,8 +88,10 @@ export const Tooltip = ({
             ...(duration !== undefined ? {duration} : {}),
             ...(hideOnClick !== undefined ? {hideOnClick} : {}),
             onCreate(createdInstance: Instance) {
-                if (className) {
-                    createdInstance.popperChildren.tooltip.classList.add(...className.split(' ').filter(Boolean));
+                const classes = className ? className.split(' ').filter(Boolean) : [];
+                appliedClassNamesRef.current = classes;
+                if (classes.length > 0) {
+                    createdInstance.popperChildren.tooltip.classList.add(...classes);
                 }
             }
         });
@@ -98,10 +101,52 @@ export const Tooltip = ({
             instance.destroy();
             instanceRef.current = null;
             reactRootRef.current = null;
+            appliedClassNamesRef.current = [];
             queueMicrotask(() => reactRoot.unmount());
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [target, placement, interactive, zIndex, popperOptions, theme, appendTo, animation, arrow, allowHTML, duration, hideOnClick, className]);
+    }, [target]);
+
+    React.useEffect(() => {
+        const instance = instanceRef.current;
+        if (!instance) {
+            return;
+        }
+
+        instance.setProps({
+            theme,
+            appendTo,
+            animation,
+            interactive,
+            ...(placement !== undefined ? {placement} : {}),
+            ...(zIndex !== undefined ? {zIndex} : {}),
+            ...(popperOptions !== undefined ? {popperOptions} : {}),
+            ...(arrow !== undefined ? {arrow} : {}),
+            ...(allowHTML !== undefined ? {allowHTML} : {}),
+            ...(duration !== undefined ? {duration} : {}),
+            ...(hideOnClick !== undefined ? {hideOnClick} : {})
+        });
+    }, [target, placement, interactive, zIndex, popperOptions, theme, appendTo, animation, arrow, allowHTML, duration, hideOnClick]);
+
+    React.useEffect(() => {
+        const instance = instanceRef.current;
+        if (!instance) {
+            return;
+        }
+
+        const next = className ? className.split(' ').filter(Boolean) : [];
+        const previous = appliedClassNamesRef.current;
+        const removed = previous.filter(cls => !next.includes(cls));
+        const added = next.filter(cls => !previous.includes(cls));
+        appliedClassNamesRef.current = next;
+
+        if (removed.length > 0) {
+            instance.popperChildren.tooltip.classList.remove(...removed);
+        }
+        if (added.length > 0) {
+            instance.popperChildren.tooltip.classList.add(...added);
+        }
+    }, [target, className]);
 
     React.useEffect(() => {
         if (reactRootRef.current) {

--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -1,8 +1,82 @@
-import Tippy, { TippyProps } from '@tippy.js/react';
 import * as React from 'react';
+import * as ReactDOM from 'react-dom/client';
+import tippy, {Instance, Placement} from 'tippy.js';
 import 'tippy.js/dist/tippy.css';
 import 'tippy.js/themes/light.css';
 
-export const Tooltip = ( props: TippyProps ) => (
-    <Tippy animation='fade' appendTo={document.body}  theme='light' interactive={true} {...props} />
-);
+const assignRef = <T,>(ref: React.Ref<T> | null | undefined, node: T | null) => {
+    if (typeof ref === 'function') {
+        ref(node);
+    } else if (ref) {
+        (ref as React.MutableRefObject<T | null>).current = node;
+    }
+};
+
+export interface TooltipProps {
+    content: React.ReactNode;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    popperOptions?: any;
+    zIndex?: number;
+    placement?: Placement;
+    interactive?: boolean;
+    theme?: string;
+    appendTo?: Element | ((ref: Element) => Element);
+    animation?: string;
+    arrow?: boolean;
+    children: React.ReactElement;
+}
+
+export const Tooltip = ({content, popperOptions, zIndex, placement, interactive = true, theme = 'light', appendTo = document.body, animation = 'fade', arrow, children}: TooltipProps) => {
+    const child = React.Children.only(children) as React.ReactElement<{ref?: React.Ref<Element>}>;
+    const [target, setTarget] = React.useState<Element | null>(null);
+    const instanceRef = React.useRef<Instance | null>(null);
+    const reactRootRef = React.useRef<ReactDOM.Root | null>(null);
+
+    const setRef = React.useCallback(
+        (node: Element | null) => {
+            assignRef(child.props.ref, node);
+            setTarget(node);
+        },
+        [child]
+    );
+
+    React.useEffect(() => {
+        if (!target) {
+            return;
+        }
+
+        const container = document.createElement('div');
+        const reactRoot = ReactDOM.createRoot(container);
+        reactRootRef.current = reactRoot;
+        reactRoot.render(content);
+
+        const instance = tippy(target, {
+            content: container,
+            theme,
+            appendTo,
+            animation,
+            interactive,
+            placement,
+            zIndex,
+            popperOptions,
+            arrow
+        });
+        instanceRef.current = instance;
+
+        return () => {
+            instance.destroy();
+            instanceRef.current = null;
+            reactRootRef.current = null;
+            queueMicrotask(() => reactRoot.unmount());
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [target, placement, interactive, zIndex, popperOptions, theme, appendTo, animation, arrow]);
+
+    React.useEffect(() => {
+        if (reactRootRef.current) {
+            reactRootRef.current.render(content);
+        }
+    }, [content]);
+
+    return React.cloneElement(child, {ref: setRef});
+};


### PR DESCRIPTION
tippy/react is a deprecated `tippy.js` wrapper that used refs in a way that is no longer supported by React 19. Here we are removing that package and replacing it with vanilla `tippy.js` (not the react wrapper), and handling all the lifecycle mechanisms that `tippy/react` used to handle ourselves.