### PR TITLE
fix(popup): handle Escape and restore focus

### DIFF
--- a/src/components/popup/popup-manager.tsx
+++ b/src/components/popup/popup-manager.tsx
@@ -45,6 +45,7 @@ export class PopupManager implements PopupApi {
             };
 
             this.popupPropsSubject.next({
+                onClose: () => closeAndResolve(false),
                 title: (
                     <span style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}><div>{title}</div> <i className='argo-icon-close' onClick={() => closeAndResolve(false)}/></span>
                 ),
@@ -89,6 +90,7 @@ export class PopupManager implements PopupApi {
             }
 
             this.popupPropsSubject.next({
+                onClose: () => closeAndResolve(null),
                 children: undefined,
                 title: (
                     <span style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between'}}><div>{title}</div> <i className='argo-icon-close' onClick={() => closeAndResolve(null)}/></span>

--- a/src/components/popup/popup.test.tsx
+++ b/src/components/popup/popup.test.tsx
@@ -1,0 +1,52 @@
+import {fireEvent, render, screen, waitFor} from '@testing-library/react';
+import * as React from 'react';
+
+import {SlidingPanel} from '../sliding-panel/sliding-panel';
+import {PopupManager} from './popup-manager';
+import {Popup, PopupProps} from './popup';
+
+const TestPopup = ({onResult}: {onResult: (result: unknown) => void}) => {
+    const [isPanelShown, setPanelShown] = React.useState(true);
+    const [popupProps, setPopupProps] = React.useState<PopupProps | null>(null);
+    const [popupManager] = React.useState(() => new PopupManager());
+
+    React.useEffect(() => {
+        const subscription = popupManager.popupProps.subscribe(setPopupProps);
+        return () => subscription.unsubscribe();
+    }, [popupManager]);
+
+    return (
+        <>
+            <SlidingPanel isShown={isPanelShown} onClose={() => setPanelShown(false)}>
+                <button onClick={() => popupManager.prompt('Delete resource', () => <textarea aria-label='Resource name' />).then(onResult)}>Delete</button>
+            </SlidingPanel>
+            {popupProps && <Popup {...popupProps} />}
+        </>
+    );
+};
+
+test('dismisses a popup before its sliding panel', async () => {
+    const onResult = jest.fn();
+    render(<TestPopup onResult={onResult} />);
+
+    const trigger = screen.getByRole('button', {name: 'Delete'});
+    trigger.focus();
+    fireEvent.click(trigger);
+
+    const dialog = screen.getByRole('dialog', {name: 'Delete resource'});
+    trigger.focus();
+
+    fireEvent.keyDown(trigger, {key: 'Escape', keyCode: 27});
+    expect(dialog).toHaveFocus();
+    expect(document.querySelector('.sliding-panel')).toHaveClass('sliding-panel--opened');
+
+    fireEvent.keyDown(dialog, {key: 'Escape', keyCode: 27});
+    expect(dialog).not.toBeInTheDocument();
+    await waitFor(() => expect(onResult).toHaveBeenCalledWith(null));
+    const panelBody = document.querySelector<HTMLElement>('.sliding-panel__body');
+    expect(panelBody).toHaveFocus();
+    expect(document.querySelector('.sliding-panel')).toHaveClass('sliding-panel--opened');
+
+    fireEvent.keyDown(panelBody!, {key: 'Escape', keyCode: 27});
+    expect(document.querySelector('.sliding-panel')).not.toHaveClass('sliding-panel--opened');
+});

--- a/src/components/popup/popup.test.tsx
+++ b/src/components/popup/popup.test.tsx
@@ -66,18 +66,20 @@ test('dismisses a popup before its sliding panel', async () => {
 
 test('does not consume Escape when onClose is not provided', () => {
     const closePanel = jest.fn();
-    render(<>
-        <SlidingPanel isShown={true} onClose={closePanel}>Panel</SlidingPanel>
+    const panel = <SlidingPanel isShown={true} onClose={closePanel}>Panel</SlidingPanel>;
+    const {rerender} = render(<>{panel}</>);
+    const previouslyFocused = document.activeElement;
+
+    rerender(<>
+        {panel}
         <Popup title='Notice'>Content</Popup>
     </>);
+
+    expect(previouslyFocused).toHaveFocus();
+    fireEvent.keyDown(document.activeElement!, {key: 'Escape', keyCode: 27});
+    expect(closePanel).toHaveBeenCalledTimes(1);
 
     const dialog = screen.getByRole('dialog', {name: 'Notice'});
     dialog.focus();
     expect(fireEvent.keyDown(dialog, {key: 'Escape', keyCode: 27})).toBe(true);
-
-    const panelBody = document.querySelector<HTMLElement>('.sliding-panel__body');
-    panelBody!.focus();
-    fireEvent.keyDown(panelBody!, {key: 'Escape', keyCode: 27});
-
-    expect(closePanel).toHaveBeenCalledTimes(1);
 });

--- a/src/components/popup/popup.test.tsx
+++ b/src/components/popup/popup.test.tsx
@@ -40,13 +40,44 @@ test('dismisses a popup before its sliding panel', async () => {
     expect(dialog).toHaveFocus();
     expect(document.querySelector('.sliding-panel')).toHaveClass('sliding-panel--opened');
 
-    fireEvent.keyDown(dialog, {key: 'Escape', keyCode: 27});
+    fireEvent.keyDown(dialog, {key: 'Escape', keyCode: 27, repeat: true});
+    expect(dialog).toBeInTheDocument();
+    expect(onResult).not.toHaveBeenCalled();
+    fireEvent.keyUp(dialog, {key: 'Escape', keyCode: 27});
+
+    const input = screen.getByRole('textbox', {name: 'Resource name'});
+    input.focus();
+    fireEvent.keyDown(input, {key: 'Escape', keyCode: 27});
+
     expect(dialog).not.toBeInTheDocument();
     await waitFor(() => expect(onResult).toHaveBeenCalledWith(null));
+    expect(onResult).toHaveBeenCalledTimes(1);
     const panelBody = document.querySelector<HTMLElement>('.sliding-panel__body');
     expect(panelBody).toHaveFocus();
     expect(document.querySelector('.sliding-panel')).toHaveClass('sliding-panel--opened');
 
+    fireEvent.keyDown(panelBody!, {key: 'Escape', keyCode: 27, repeat: true});
+    expect(document.querySelector('.sliding-panel')).toHaveClass('sliding-panel--opened');
+    fireEvent.keyUp(panelBody!, {key: 'Escape', keyCode: 27});
+
     fireEvent.keyDown(panelBody!, {key: 'Escape', keyCode: 27});
     expect(document.querySelector('.sliding-panel')).not.toHaveClass('sliding-panel--opened');
+});
+
+test('does not consume Escape when onClose is not provided', () => {
+    const closePanel = jest.fn();
+    render(<>
+        <SlidingPanel isShown={true} onClose={closePanel}>Panel</SlidingPanel>
+        <Popup title='Notice'>Content</Popup>
+    </>);
+
+    const dialog = screen.getByRole('dialog', {name: 'Notice'});
+    dialog.focus();
+    expect(fireEvent.keyDown(dialog, {key: 'Escape', keyCode: 27})).toBe(true);
+
+    const panelBody = document.querySelector<HTMLElement>('.sliding-panel__body');
+    panelBody!.focus();
+    fireEvent.keyDown(panelBody!, {key: 'Escape', keyCode: 27});
+
+    expect(closePanel).toHaveBeenCalledTimes(1);
 });

--- a/src/components/popup/popup.tsx
+++ b/src/components/popup/popup.tsx
@@ -21,15 +21,19 @@ require('./popup.scss');
 
 export const Popup = (props: PopupProps) => {
     const {onClose} = props;
+    const canClose = !!onClose;
     const dialogRef = React.useRef<HTMLDivElement>(null);
     const titleId = React.useId();
 
     React.useLayoutEffect(() => {
+        if (!canClose) {
+            return;
+        }
         const previouslyFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
         const restoreFocus = previouslyFocused?.closest('.sliding-panel--opened')?.querySelector<HTMLElement>('.sliding-panel__body') ?? previouslyFocused;
         dialogRef.current?.focus();
         return () => restoreFocus?.isConnected && restoreFocus.focus();
-    }, []);
+    }, [canClose]);
 
     React.useEffect(() => {
         const handleEscape = (event: KeyboardEvent) => {

--- a/src/components/popup/popup.tsx
+++ b/src/components/popup/popup.tsx
@@ -6,6 +6,7 @@ export interface BasePopupProps {
     titleColor?: string;
     title: string | React.ReactNode;
     footer?: React.ReactNode;
+    onClose?: () => void;
 }
 
 export type PopupPropsWithContent = BasePopupProps & { content: React.ComponentType };
@@ -18,26 +19,61 @@ function isPopupWithChildren(value: PopupProps): value is PopupPropsWithChildren
 
 require('./popup.scss');
 
-export const Popup = (props: PopupProps) => (
-    <div className='popup-overlay'>
-        <div className='popup-container'>
-            <div className={`row popup-container__header ${props.titleColor !== undefined ? 'popup-container__header__' + props.titleColor : 'popup-container__header__normal'}`}>
-                {props.title}
-            </div>
-            <div className='row popup-container__body'>
-                {props.icon &&
-                    <div className='columns popup-container__icon'>
-                        <i className={`${props.icon.name} ${props.icon.color}`}/>
+export const Popup = (props: PopupProps) => {
+    const {onClose} = props;
+    const dialogRef = React.useRef<HTMLDivElement>(null);
+    const titleId = React.useId();
+
+    React.useLayoutEffect(() => {
+        const previouslyFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+        const restoreFocus = previouslyFocused?.closest('.sliding-panel--opened')?.querySelector<HTMLElement>('.sliding-panel__body') ?? previouslyFocused;
+        dialogRef.current?.focus();
+        return () => restoreFocus?.isConnected && restoreFocus.focus();
+    }, []);
+
+    React.useEffect(() => {
+        const handleEscape = (event: KeyboardEvent) => {
+            if (event.key !== 'Escape') {
+                return;
+            }
+            event.preventDefault();
+            event.stopPropagation();
+            if (document.activeElement !== dialogRef.current) {
+                dialogRef.current?.focus();
+                return;
+            }
+            onClose?.();
+        };
+        document.addEventListener('keydown', handleEscape, true);
+        return () => document.removeEventListener('keydown', handleEscape, true);
+    }, [onClose]);
+
+    return (
+        <div className='popup-overlay'>
+            <div
+                ref={dialogRef}
+                className='popup-container'
+                role='dialog'
+                aria-labelledby={titleId}
+                tabIndex={-1}>
+                <div id={titleId} className={`row popup-container__header ${props.titleColor !== undefined ? 'popup-container__header__' + props.titleColor : 'popup-container__header__normal'}`}>
+                    {props.title}
+                </div>
+                <div className='row popup-container__body'>
+                    {props.icon &&
+                        <div className='columns popup-container__icon'>
+                            <i className={`${props.icon.name} ${props.icon.color}`}/>
+                        </div>
+                    }
+                    <div className={classNames('columns', {'large-10': !!props.icon, 'large-12': !props.icon}, !props.icon && 'popup-container__body__hasNoIcon')}>
+                        {isPopupWithChildren(props) ? props.children : <props.content/>}
                     </div>
-                }
-                <div className={classNames('columns', {'large-10': !!props.icon, 'large-12': !props.icon}, !props.icon && 'popup-container__body__hasNoIcon')}>
-                    {isPopupWithChildren(props) ? props.children : <props.content/>}
+                </div>
+
+                <div className={classNames('row popup-container__footer', {'popup-container__footer--additional-padding': !!props.icon})}>
+                    {props.footer}
                 </div>
             </div>
-
-            <div className={classNames('row popup-container__footer', {'popup-container__footer--additional-padding': !!props.icon})}>
-                {props.footer}
-            </div>
         </div>
-    </div>
-);
+    );
+};

--- a/src/components/popup/popup.tsx
+++ b/src/components/popup/popup.tsx
@@ -33,16 +33,19 @@ export const Popup = (props: PopupProps) => {
 
     React.useEffect(() => {
         const handleEscape = (event: KeyboardEvent) => {
-            if (event.key !== 'Escape') {
+            if (event.key !== 'Escape' || event.isComposing || !onClose) {
                 return;
             }
             event.preventDefault();
             event.stopPropagation();
-            if (document.activeElement !== dialogRef.current) {
+            if (event.repeat) {
+                return;
+            }
+            if (!dialogRef.current?.contains(document.activeElement)) {
                 dialogRef.current?.focus();
                 return;
             }
-            onClose?.();
+            onClose();
         };
         document.addEventListener('keydown', handleEscape, true);
         return () => document.removeEventListener('keydown', handleEscape, true);

--- a/v2/shared/keypress.tsx
+++ b/v2/shared/keypress.tsx
@@ -113,6 +113,10 @@ export interface GroupMap {
 }
 
 const handlePress = (e: KeyboardEvent, state: GroupMap) => {
+    // Holding Escape must not dismiss another layer after focus is restored.
+    if (e.keyCode === Key.ESCAPE && e.repeat) {
+        return;
+    }
     const {groups, groupForKey} = state;
     const g = groupForKey[e.keyCode];
 


### PR DESCRIPTION
## Summary

When a popup is opened from a sliding panel, focus can remain on or move back to an element behind the popup. Pressing Escape can then close the panel while leaving the popup open.

This change:

- focuses the popup when it opens;
- captures Escape while the popup is open, moving focus back to the dialog first and closing it on the next press;
- restores focus to the sliding panel body after the popup closes;
- connects `PopupManager` confirm and prompt popups to the Escape close behavior;
- adds a regression test covering `PopupManager.prompt` with focus moved behind the popup.

Related to argoproj/argo-cd#29286

## Testing

- `pnpm exec jest --runInBand` (66 tests passed)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `git diff --check`

## Before / After
### Before
Pressing `Esc` closes the underlying sliding panel while leaving the delete dialog open.

https://github.com/user-attachments/assets/a2bb183e-0819-4c08-a72c-248ea69b2643


### After
The first `Esc` returns focus to the dialog. The second closes the dialog and restores focus to the sliding panel.

https://github.com/user-attachments/assets/988d1707-a7e8-48d9-a490-43324426b04d
